### PR TITLE
Fixed to not display the offer screen when an error occurs.

### DIFF
--- a/tw2023_wallet/Feature/IssueCredential/Views/CredentialOffer.swift
+++ b/tw2023_wallet/Feature/IssueCredential/Views/CredentialOffer.swift
@@ -36,6 +36,7 @@ struct CredentialOfferView: View {
     var viewModel: CredentialOfferViewModel
     @State private var navigateToHome = false
     @State private var navigateToPinInput = false
+    @State private var showErrorDialog = false
 
     init(viewModel: CredentialOfferViewModel = CredentialOfferViewModel()) {
         self.viewModel = viewModel
@@ -123,11 +124,21 @@ struct CredentialOfferView: View {
                     try viewModel.initialize(rawCredentialOfferString: args.credentialOffer!)
                     try await viewModel.loadData()
                 }catch{
+                    self.showErrorDialog = true
                     print("credential offerが正しくありません")
                     print(error)
                 }
             }
         }
+        .alert(isPresented: $showErrorDialog) {
+                    Alert(
+                        title: Text("error"),
+                        message: Text("failed_to_show_credential_offer"),
+                        dismissButton: .default(Text("OK")) {
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                    )
+                }
     }
 }
 

--- a/tw2023_wallet/Localizable.xcstrings
+++ b/tw2023_wallet/Localizable.xcstrings
@@ -598,6 +598,38 @@
     "Enter PIN Code" : {
 
     },
+    "error" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "エラー"
+          }
+        }
+      }
+    },
+    "failed_to_show_credential_offer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to read information required for certificate issuance. Please start the operation again from the beginning."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "証明書発行に必要な情報の読み込みに失敗しました。操作を始めからやり直してください。"
+          }
+        }
+      }
+    },
     "familyName" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
- Improved handling of cases in which the retrieval of CredentialOffer contents fails.
- Specifically, an error dialog has been implemented, and the button can be pressed to return to the previous screen.