### PR TITLE
Fix test failure

### DIFF
--- a/tw2023_wallet/Feature/IssueCredential/ViewModels/CredentialOfferViewModel.swift
+++ b/tw2023_wallet/Feature/IssueCredential/ViewModels/CredentialOfferViewModel.swift
@@ -57,7 +57,7 @@ class CredentialOfferViewModel {
             let proofRequired = cNonce != nil
             let isKeyPairExist = KeyPairUtil.isKeyPairExist(alias: Constants.Cryptography.KEY_BINDING)
             if (!isKeyPairExist && proofRequired) {
-                _ = try KeyPairUtil.generateSignVerifyKeyPair(alias: Constants.Cryptography.KEY_BINDING)
+                try KeyPairUtil.generateSignVerifyKeyPair(alias: Constants.Cryptography.KEY_BINDING)
             }
             
             // proof generation

--- a/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
+++ b/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
@@ -232,7 +232,11 @@ class SharingRequestViewModel {
         print("get keypair")
         let keyBinding = KeyBindingImpl(keyAlias: Constants.Cryptography.KEY_BINDING)
         openIdProvider.setKeyBinding(keyBinding: keyBinding)
-        let result = await openIdProvider.respondVPResponse(credentials: credentials)
+        
+        let delegate = NoRedirectDelegate()
+        let configuration = URLSessionConfiguration.default
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        let result = await openIdProvider.respondVPResponse(credentials: credentials, using: session)
         switch result {
         case .success(let sharedResult):
             print("sharing sucess")

--- a/tw2023_wallet/Services/OID/OpenIdProvider.swift
+++ b/tw2023_wallet/Services/OID/OpenIdProvider.swift
@@ -480,11 +480,7 @@ func sendRequest<T: Decodable>(
 
     request.httpBody = formBody.data(using: .utf8)
     request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    
-    let delegate = NoRedirectDelegate()
-    let configuration = URLSessionConfiguration.default
-    let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
-    
+        
     do {
         let (data, response) = try await session.data(for: request)
         

--- a/tw2023_wallet/Signature/SignatureUtil.swift
+++ b/tw2023_wallet/Signature/SignatureUtil.swift
@@ -199,11 +199,11 @@ enum SignatureUtil {
         }
     }
     
-    static func getX509CertificatesFromUrl(url: String) -> [Certificate]? {
+    static func getX509CertificatesFromUrl(url: String, session: URLSession = URLSession.shared) -> [Certificate]? {
         var result: [Certificate]?
         let dispatchGroup = DispatchGroup()
         dispatchGroup.enter()
-        SignatureUtil.getX509CertificatesFromUrl_(url: url) { certificates, error in
+        SignatureUtil.getX509CertificatesFromUrl_(url: url, session: session) { certificates, error in
             defer {
                 dispatchGroup.leave()
             }
@@ -217,13 +217,13 @@ enum SignatureUtil {
         return result
     }
     
-    static func getX509CertificatesFromUrl_(url: String, completion: @escaping ([Certificate]?, Error?) -> Void) {
+    static func getX509CertificatesFromUrl_(url: String, session: URLSession = URLSession.shared, completion: @escaping ([Certificate]?, Error?) -> Void) {
         guard let requestURL = URL(string: url) else {
             completion(nil, NSError(domain: "Invalid URL", code: 0, userInfo: nil))
             return
         }
         
-        let task = URLSession.shared.dataTask(with: requestURL) { data, response, error in
+        let task = session.dataTask(with: requestURL) { data, response, error in
             if let error = error {
                 completion(nil, error)
                 return

--- a/tw2023_wallet/Utils/KeyPairUtil.swift
+++ b/tw2023_wallet/Utils/KeyPairUtil.swift
@@ -23,7 +23,7 @@ enum JwkError: Error {
 
 class KeyPairUtil {
     
-    static func generateSignVerifyKeyPair(alias: String) throws -> (SecKey?, SecKey?) {
+    static func generateSignVerifyKeyPair(alias: String) throws {
         
         let access = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
@@ -48,9 +48,6 @@ class KeyPairUtil {
             throw error!.takeRetainedValue() as Error
         }
         
-        let publicKey = SecKeyCopyPublicKey(privateKey)
-        
-        return (privateKey, publicKey)
     }
     
     static func isKeyPairExist(alias: String) -> Bool{

--- a/tw2023_wallet/Utils/KeyPairUtil.swift
+++ b/tw2023_wallet/Utils/KeyPairUtil.swift
@@ -140,10 +140,10 @@ class KeyPairUtil {
     
     static func createPublicKey(jwk: [String: String]) throws -> SecKey {
         // Check if the necessary JWK components are present
-        guard let xBase64 = jwk["x"],
-              let yBase64 = jwk["y"],
-              let xData = Data(base64Encoded: xBase64),
-              let yData = Data(base64Encoded: yBase64) else {
+        guard let xBase64Url = jwk["x"],
+              let yBase64Url = jwk["y"],
+              let xData = xBase64Url.base64UrlDecoded(),
+              let yData = yBase64Url.base64UrlDecoded() else {
             throw JwkError.UnableToConversionError
         }
         

--- a/tw2023_walletTests/Resources/KeyBindingTests.swift
+++ b/tw2023_walletTests/Resources/KeyBindingTests.swift
@@ -16,9 +16,8 @@ final class KeyBindingTests: XCTestCase {
     override func setUpWithError() throws {
         super.setUp()
         // キーペアの生成
-        let keys = try KeyPairUtil.generateSignVerifyKeyPair(alias: keyAlias)
-        privateKey = keys.0
-        publicKey = keys.1
+        try KeyPairUtil.generateSignVerifyKeyPair(alias: keyAlias)
+        (privateKey, publicKey) = KeyPairUtil.getKeyPair(alias: keyAlias)!
     }
 
     override func tearDownWithError() throws {
@@ -33,6 +32,7 @@ final class KeyBindingTests: XCTestCase {
         let selectedDisclosures = [Disclosure(disclosure: "disclosureSample", key: "keySample", value: "valueSample")]
         let aud = "audSample"
         let nonce = "nonceSample"
+        
 
         // JWTの生成
         let keyBinding = KeyBindingImpl(keyAlias: keyAlias)

--- a/tw2023_walletTests/VCIMetadataUtilTests.swift
+++ b/tw2023_walletTests/VCIMetadataUtilTests.swift
@@ -152,7 +152,7 @@ final class VCIMetadataUtilTests: XCTestCase {
             let deserialized = VCIMetadataUtil.deserializeDisplayByClaimMap(displayMapString: serialized)
 
             XCTAssertNotNil(deserialized)
-            XCTAssertEqual(deserialized.count, 5)
+            XCTAssertEqual(deserialized.count, 6)
 
             if let display1 = deserialized["given_name"] {
                 XCTAssertEqual(display1.count, 2)


### PR DESCRIPTION
# PR Overview

## Background and Purpose

- Fixed to pass all existing test cases.

## Items implemented

- Mocked network access appropriately.
- The return value of `generateSignVerifyKeyPair` was incorrect and made unavailable.
  - Instead, `getKeyPair` can be used.
- Fixed a problem where appropriate class variables were not set when testing `respondVPResponse`.
- Fixed incorrect use of base64 encoding.
