### PR TITLE
Setup github workflow to run basical test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           xcode-version: '15.4.0'
       - name: UnitTest
-        run: xdebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet
+        run: xcodebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+run-name: Initiated by ${{ github.actor }} for commit ${{ github.sha }}
+on:
+  pull_request:
+    types:
+      - synchronize
+      - reopened
+      - opened
+jobs:
+  test-job:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4.0'
+      - name: UnitTest
+        run: xdebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           xcode-version: '15.4.0'
       - name: UnitTest
-        run: xcodebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet -only-testing:tw2023_walletTests
+        run: xcodebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' -only-testing:tw2023_walletTests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           xcode-version: '15.4.0'
       - name: UnitTest
-        run: xcodebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet
+        run: xcodebuild test -project tw2023_wallet.xcodeproj -scheme tw2023_wallet -only-testing:tw2023_walletTests

--- a/tw2023_walletTests/Utils/ZipUtilTest.swift
+++ b/tw2023_walletTests/Utils/ZipUtilTest.swift
@@ -10,10 +10,6 @@ import XCTest
 
 class ZipUtilTests: XCTestCase {
     
-    func testFail() {
-        XCTFail("fail")
-    }
-    
     func testCompressionAndDecompression() {
         let inputString = "test string"
         

--- a/tw2023_walletTests/Utils/ZipUtilTest.swift
+++ b/tw2023_walletTests/Utils/ZipUtilTest.swift
@@ -10,6 +10,10 @@ import XCTest
 
 class ZipUtilTests: XCTestCase {
     
+    func testFail() {
+        XCTFail("fail")
+    }
+    
     func testCompressionAndDecompression() {
         let inputString = "test string"
         


### PR DESCRIPTION
Set up a workflow to run `xcodebuild test` using GitHub Actions. 
Processing related to UI testing seems to be difficult due to the relationship with the emulator, so we are only running tests related to logic for now. More advanced tests, including UI tests, will be handled as separate tasks as needed.