### PR TITLE
Remove hard coded credential type

### DIFF
--- a/tw2023_wallet.xcodeproj/project.pbxproj
+++ b/tw2023_wallet.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		A84AB70B2B50B98C00E8C88B /* CredentialSharingHistoryManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84AB70A2B50B98C00E8C88B /* CredentialSharingHistoryManagerTest.swift */; };
 		A84AB70D2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84AB70C2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift */; };
 		A8509C292B82315D00B28C35 /* RecipientClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509C282B82315D00B28C35 /* RecipientClaims.swift */; };
+		A857C25A2C0DD3200059A82F /* swift-format in Frameworks */ = {isa = PBXBuildFile; productRef = A857C2592C0DD3200059A82F /* swift-format */; };
 		A89108022B82D1650060DD71 /* RecipientClaimsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89108012B82D1650060DD71 /* RecipientClaimsViewModel.swift */; };
 		A89108042B82D2880060DD71 /* RecipientClaimsPreviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89108032B82D2880060DD71 /* RecipientClaimsPreviewModel.swift */; };
 		A891080C2B84785F0060DD71 /* credential_sharing_history.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = A891080B2B84785F0060DD71 /* credential_sharing_history.pb.swift */; };
@@ -182,9 +183,6 @@
 		A8C810432B82042300CF8CD6 /* SharingToModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C8103E2B82042200CF8CD6 /* SharingToModel.swift */; };
 		A8C810442B82042300CF8CD6 /* SharingToRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C810402B82042200CF8CD6 /* SharingToRow.swift */; };
 		A8C810452B82042300CF8CD6 /* SharingTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C810412B82042200CF8CD6 /* SharingTo.swift */; };
-		A8CC48782C0D8EE700113623 /* SwiftFormat in Frameworks */ = {isa = PBXBuildFile; productRef = A8CC48772C0D8EE700113623 /* SwiftFormat */; };
-		A8CC487A2C0D8EE700113623 /* SwiftFormatConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = A8CC48792C0D8EE700113623 /* SwiftFormatConfiguration */; };
-		A8CC487C2C0D8EE700113623 /* swift-format in Frameworks */ = {isa = PBXBuildFile; productRef = A8CC487B2C0D8EE700113623 /* swift-format */; };
 		A8E892302B3A705D009F3755 /* SerializeUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E8922F2B3A705D009F3755 /* SerializeUtil.swift */; };
 		F613F8602B55FEF800DA4B9E /* PinCodeInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = F613F85F2B55FEF800DA4B9E /* PinCodeInput.swift */; };
 		F621E1F32B6C654D0034BF95 /* RecipientDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = F621E1F22B6C654D0034BF95 /* RecipientDetail.swift */; };
@@ -464,19 +462,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				A89297572B3AA1EB007315BE /* Gzip in Frameworks */,
-				A8CC48782C0D8EE700113623 /* SwiftFormat in Frameworks */,
 				A8137C482B484454008CA5AC /* JWTDecode in Frameworks */,
-				A8CC487A2C0D8EE700113623 /* SwiftFormatConfiguration in Frameworks */,
 				A89297622B3AF26F007315BE /* SwiftASN1 in Frameworks */,
 				A83039D52B4E7449004139A7 /* SwiftProtobuf in Frameworks */,
 				A81087252B3D66A1004425DE /* X509 in Frameworks */,
 				A89297652B3AF487007315BE /* ASN1Decoder in Frameworks */,
 				8B7F89212B8D7507005DA52B /* Zip in Frameworks */,
-				A8CC487C2C0D8EE700113623 /* swift-format in Frameworks */,
 				8B297C4B2B39AB8900D2998D /* SwiftyJSON in Frameworks */,
 				8B0E0A942B3BC36E0080F6A3 /* web3swift in Frameworks */,
 				8BF745992B4FF85F000F74A9 /* JOSESwift in Frameworks */,
 				F6A239AC2B4E709200B09F17 /* IGIdenticon in Frameworks */,
+				A857C25A2C0DD3200059A82F /* swift-format in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1189,9 +1185,7 @@
 				8BF745982B4FF85F000F74A9 /* JOSESwift */,
 				F6A239AB2B4E709200B09F17 /* IGIdenticon */,
 				8B7F89202B8D7507005DA52B /* Zip */,
-				A8CC48772C0D8EE700113623 /* SwiftFormat */,
-				A8CC48792C0D8EE700113623 /* SwiftFormatConfiguration */,
-				A8CC487B2C0D8EE700113623 /* swift-format */,
+				A857C2592C0DD3200059A82F /* swift-format */,
 			);
 			productName = tw2023_wallet;
 			productReference = 8B81E2992B33CC4000ED3B4E /* tw2023_wallet.app */;
@@ -1281,7 +1275,7 @@
 				8BF745972B4FF85F000F74A9 /* XCRemoteSwiftPackageReference "JOSESwift" */,
 				F6A239AA2B4E709200B09F17 /* XCRemoteSwiftPackageReference "IGIdenticon" */,
 				8B7F891F2B8D7507005DA52B /* XCRemoteSwiftPackageReference "Zip" */,
-				A8CC48762C0D8EE600113623 /* XCRemoteSwiftPackageReference "swift-format" */,
+				A857C2582C0DD3200059A82F /* XCRemoteSwiftPackageReference "swift-format" */,
 			);
 			productRefGroup = 8B81E29A2B33CC4000ED3B4E /* Products */;
 			projectDirPath = "";
@@ -1965,6 +1959,14 @@
 				minimumVersion = 1.25.2;
 			};
 		};
+		A857C2582C0DD3200059A82F /* XCRemoteSwiftPackageReference "swift-format" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-format";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 510.1.0;
+			};
+		};
 		A89297552B3AA1EB007315BE /* XCRemoteSwiftPackageReference "GzipSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/1024jp/GzipSwift.git";
@@ -1987,14 +1989,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.9.0;
-			};
-		};
-		A8CC48762C0D8EE600113623 /* XCRemoteSwiftPackageReference "swift-format" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-format";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 510.1.0;
 			};
 		};
 		F6A239AA2B4E709200B09F17 /* XCRemoteSwiftPackageReference "IGIdenticon" */ = {
@@ -2048,6 +2042,11 @@
 			package = A83039D32B4E7449004139A7 /* XCRemoteSwiftPackageReference "swift-protobuf" */;
 			productName = SwiftProtobuf;
 		};
+		A857C2592C0DD3200059A82F /* swift-format */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A857C2582C0DD3200059A82F /* XCRemoteSwiftPackageReference "swift-format" */;
+			productName = "swift-format";
+		};
 		A89297562B3AA1EB007315BE /* Gzip */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A89297552B3AA1EB007315BE /* XCRemoteSwiftPackageReference "GzipSwift" */;
@@ -2062,21 +2061,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A89297632B3AF487007315BE /* XCRemoteSwiftPackageReference "ASN1Decoder" */;
 			productName = ASN1Decoder;
-		};
-		A8CC48772C0D8EE700113623 /* SwiftFormat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A8CC48762C0D8EE600113623 /* XCRemoteSwiftPackageReference "swift-format" */;
-			productName = SwiftFormat;
-		};
-		A8CC48792C0D8EE700113623 /* SwiftFormatConfiguration */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A8CC48762C0D8EE600113623 /* XCRemoteSwiftPackageReference "swift-format" */;
-			productName = SwiftFormatConfiguration;
-		};
-		A8CC487B2C0D8EE700113623 /* swift-format */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A8CC48762C0D8EE600113623 /* XCRemoteSwiftPackageReference "swift-format" */;
-			productName = "swift-format";
 		};
 		F6A239AB2B4E709200B09F17 /* IGIdenticon */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/tw2023_wallet/Feature/Credentials/Views/CredentialDetail.swift
+++ b/tw2023_wallet/Feature/Credentials/Views/CredentialDetail.swift
@@ -145,7 +145,7 @@ struct CredentialDetail: View {
                     .padding(.horizontal, 16)  // 左右に16dpのパディング
                     .padding(.vertical, 16)
                 }
-                .navigationTitle(LocalizedStringKey(self.credential.credentialType.rawValue))
+                .navigationTitle(LocalizedStringKey(self.credential.credentialType))
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationDestination(isPresented: $navigateToIssuerDetail) {
                     IssuerDetail(credential: credential)

--- a/tw2023_wallet/Feature/Credentials/Views/CredentialList.swift
+++ b/tw2023_wallet/Feature/Credentials/Views/CredentialList.swift
@@ -57,7 +57,7 @@ struct CredentialList: View {
                         LazyVStack(spacing: 16) {
                             ForEach(viewModel.dataModel.credentials) { credential in
                                 VStack(alignment: .leading) {
-                                    Text(LocalizedStringKey(credential.credentialType.rawValue))
+                                    Text(LocalizedStringKey(credential.credentialType))
                                         .font(.headline)
                                         .padding(.leading, 16)
                                     NavigationLink(

--- a/tw2023_wallet/Feature/Credentials/Views/CredentialListForSharing.swift
+++ b/tw2023_wallet/Feature/Credentials/Views/CredentialListForSharing.swift
@@ -29,7 +29,7 @@ struct CredentialListForSharing: View {
                 ScrollView {
                     ForEach(viewModel.dataModel.credentials) { credential in
                         VStack(alignment: .leading) {
-                            Text(LocalizedStringKey(credential.credentialType.rawValue))
+                            Text(LocalizedStringKey(credential.credentialType))
                                 .font(.headline)
                                 .padding(.leading, 16)
                             NavigationLink(value: ScreensOnFullScreen.credentialDetail(credential))

--- a/tw2023_wallet/Helper/VCIMetadataUtil.swift
+++ b/tw2023_wallet/Helper/VCIMetadataUtil.swift
@@ -31,19 +31,23 @@ class VCIMetadataUtil {
 
     static func extractTypes(format: String, credential: String) throws -> [String] {
         var types: [String] = []
+        
+        switch format {
+            case "vc+sd-jwt":
+                let jwt = divideSDJwt(sdJwt: credential).issuerSignedJwt
+                let decoded = try decodeJWTPayload(jwt: jwt)
+                let vct = decoded["vct"] as! String
+                types = [vct]
+            case "jwt_vc_json":
+                let decoded = try decodeJWTPayload(jwt: credential)
+                print(decoded)
+                let vc = decoded["vc"] as! [String: Any]
+                let typeList = vc["type"] as! [String]
+                types = typeList
+            default:
+                print("Unsupported Credential Format: \(format)")
+        }
 
-        if format == "vc+sd-jwt" {
-            let jwt = divideSDJwt(sdJwt: credential).issuerSignedJwt
-            let decoded = try decodeJWTPayload(jwt: jwt)
-            let vct = decoded["vct"] as! String
-            types = [vct]
-        }
-        else if format == "jwt_vc_json" {
-            let decoded = try decodeJWTPayload(jwt: credential)
-            let vc = decoded["vc"] as! [String: Any]
-            let typeList = vc["type"] as! [String]
-            types = typeList
-        }
         return types
     }
 

--- a/tw2023_wallet/Helper/VCIMetadataUtil.swift
+++ b/tw2023_wallet/Helper/VCIMetadataUtil.swift
@@ -31,7 +31,7 @@ class VCIMetadataUtil {
 
     static func extractTypes(format: String, credential: String) throws -> [String] {
         var types: [String] = []
-        
+
         switch format {
             case "vc+sd-jwt":
                 let jwt = divideSDJwt(sdJwt: credential).issuerSignedJwt

--- a/tw2023_wallet/Models/Credential.swift
+++ b/tw2023_wallet/Models/Credential.swift
@@ -19,7 +19,7 @@ struct Credential: Codable, Identifiable, Hashable {
     var backgroundColor: String?
     var backgroundImageUrl: String?
     var textColor: String?
-    var credentialType: CredentialType
+    var credentialType: String
     // var disclosure: Dictionary<String, String>?以下は同様の意味
     var disclosure: [String: String]?
     var certificates: [Certificate?]?
@@ -56,10 +56,4 @@ struct Credential: Codable, Identifiable, Hashable {
     static func == (lhs: Credential, rhs: Credential) -> Bool {
         return lhs.id == rhs.id
     }
-}
-
-enum CredentialType: String, Codable {
-    case identityCredential = "IdentityCredential"
-    case employeeIdentificationCredential = "EmployeeIdentificationCredential"
-    case participationCertificate = "ParticipationCertificate"
 }

--- a/tw2023_wallet/Models/TempIssuerMetaData.swift
+++ b/tw2023_wallet/Models/TempIssuerMetaData.swift
@@ -13,7 +13,7 @@ struct TempIssuerMetaData: Codable {
     var issuerDisplayName: String
     var issuerDisplayLogoUrl: String?
     var credentialsSupportedDisplayName: String
-    var credentialType: CredentialType
+    var credentialType: String
     var displayNames: [String]
 
     var issuerDisplayLogoImage: AnyView? {

--- a/tw2023_wallet/datastore/CredentialDataManager.swift
+++ b/tw2023_wallet/datastore/CredentialDataManager.swift
@@ -117,10 +117,8 @@ extension Datastore_CredentialData {
     }
 
     private func getBackgroundImage() -> String? {
-        guard let metaData = self.parsedMetaData() else {
-            return nil
-        }
-        guard let supportedName = metaData.credentialsSupported.keys.first,  // todo: 1つめを前提としている
+        guard let metaData = self.parsedMetaData(),
+            let supportedName = metaData.credentialsSupported.keys.first,  // todo: 1つめを前提としている
             let supported = metaData.credentialsSupported[supportedName],
             let displays = supported.display,
             let firstDisplay = displays.first,  // todo: 1つめを前提としている
@@ -141,17 +139,16 @@ extension Datastore_CredentialData {
     }
 
     func toCredential() -> Credential? {
-        guard let metaData = self.parsedMetaData() else {
+        guard let metaData = self.parsedMetaData(),
+            let disclosure = self.getDisclosure()
+        else {
             return nil
         }
+
         let issuer = metaData.credentialIssuer
         let display = metaData.display?.first
         let issuerName = display?.name ?? "Unknown Issuer"
         let iat = self.convertUnixTimestampToDate(unixTimestamp: self.iat)
-
-        guard let disclosure = getDisclosure() else {
-            return nil
-        }
 
         // 最低限のデータのみ詰めている。必要があれば追加する。
         let result = Credential(

--- a/tw2023_wallet/datastore/CredentialDataManager.swift
+++ b/tw2023_wallet/datastore/CredentialDataManager.swift
@@ -103,6 +103,7 @@ extension Datastore_CredentialData {
                     let vcDict = tmp["vc"] as? [String: Any],
                     let credentialSubject = vcDict["credentialSubject"] as? [String: Any]
                 else {
+                    print("Credential Data Not Found")
                     return nil
                 }
                 var disclousre = [String: String]()
@@ -112,6 +113,7 @@ extension Datastore_CredentialData {
                 }
                 return disclousre
             default:
+            print("Usupported Credential Format: \(self.format)")
                 return nil
         }
     }
@@ -142,6 +144,7 @@ extension Datastore_CredentialData {
         guard let metaData = self.parsedMetaData(),
             let disclosure = self.getDisclosure()
         else {
+            print("Unable to get metaData or disclosure")
             return nil
         }
 
@@ -159,7 +162,7 @@ extension Datastore_CredentialData {
             issuerDisplayName: issuerName,
             issuedAt: iat,
             backgroundImageUrl: getBackgroundImage(),
-            credentialType: CredentialType(rawValue: self.type)!,
+            credentialType: self.type,
             disclosure: disclosure,
             qrDisplay: self.generateQRDisplay(),
             metaData: metaData

--- a/tw2023_wallet/datastore/CredentialDataManager.swift
+++ b/tw2023_wallet/datastore/CredentialDataManager.swift
@@ -170,7 +170,7 @@ extension Datastore_CredentialData {
 }
 
 extension CredentialDataEntity {
-    func toCredentialData() -> Datastore_CredentialData {
+    func toDatastore_CredentialData() -> Datastore_CredentialData {
         let helper = EncryptionHelper()
         var credentialData = Datastore_CredentialData()
         credentialData.id = self.id!
@@ -274,7 +274,7 @@ class CredentialDataManager {
             let credentialEntities = try context.fetch(fetchRequest)
 
             for credentialEntity in credentialEntities {
-                let credentialData = credentialEntity.toCredentialData()
+                let credentialData = credentialEntity.toDatastore_CredentialData()
                 credentials.append(credentialData)
             }
         }
@@ -294,7 +294,7 @@ class CredentialDataManager {
             let credentialEntities = try context.fetch(fetchRequest)
 
             if let credentialEntity = credentialEntities.first {
-                return credentialEntity.toCredentialData()
+                return credentialEntity.toDatastore_CredentialData()
             }
             else {
                 return nil

--- a/tw2023_wallet/datastore/CredentialDataManager.swift
+++ b/tw2023_wallet/datastore/CredentialDataManager.swift
@@ -113,7 +113,7 @@ extension Datastore_CredentialData {
                 }
                 return disclousre
             default:
-            print("Usupported Credential Format: \(self.format)")
+                print("Usupported Credential Format: \(self.format)")
                 return nil
         }
     }

--- a/tw2023_walletTests/datastore/CredentialDataManagerTest.swift
+++ b/tw2023_walletTests/datastore/CredentialDataManagerTest.swift
@@ -167,7 +167,7 @@ class CredentialDataManagerTests: XCTestCase {
     }
 
     func testToCredential() {
-        
+
         guard
             let url = Bundle.main.url(
                 forResource: "credential_issuer_metadata_jwt_vc", withExtension: "json"),
@@ -176,8 +176,7 @@ class CredentialDataManagerTests: XCTestCase {
             XCTFail("Cannot read credential_issuer_metadata.json")
             return
         }
-        
-        
+
         var testCredentialData = Datastore_CredentialData()
         testCredentialData.id = "1"
         testCredentialData.format = "jwt_vc_json"

--- a/tw2023_walletTests/datastore/CredentialDataManagerTest.swift
+++ b/tw2023_walletTests/datastore/CredentialDataManagerTest.swift
@@ -165,4 +165,43 @@ class CredentialDataManagerTests: XCTestCase {
         XCTAssertEqual(retrievedCredential?.credential, testCredentialData.credential)
         // ... add more assertions for other properties
     }
+
+    func testToCredential() {
+        
+        guard
+            let url = Bundle.main.url(
+                forResource: "credential_issuer_metadata_jwt_vc", withExtension: "json"),
+            let jsonData = try? Data(contentsOf: url)
+        else {
+            XCTFail("Cannot read credential_issuer_metadata.json")
+            return
+        }
+        
+        
+        var testCredentialData = Datastore_CredentialData()
+        testCredentialData.id = "1"
+        testCredentialData.format = "jwt_vc_json"
+        testCredentialData.credential =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ2YyI6eyJ0eXBlIjpbIlR5cGUxIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOiJqaG9uIHNtaXRoIn19fQ.oJgBUQB_YHrRwMeXjpLPvdvuXEFNgFfnq6iJEa-Lapw"
+        testCredentialData.cNonce = "CNonce1"
+        testCredentialData.cNonceExpiresIn = 3600
+        testCredentialData.iss = "Iss1"
+        testCredentialData.iat = 1_638_290_000
+        testCredentialData.exp = 1_638_293_600
+        testCredentialData.type = "Type1"
+        testCredentialData.accessToken = "AccessToken1"
+        testCredentialData.credentialIssuerMetadata = String(decoding: jsonData, as: UTF8.self)
+        // Convert to Credential
+        let credential = testCredentialData.toCredential()
+
+        // Assert that the generated credential matches the input data
+        XCTAssertNotNil(credential)
+        XCTAssertEqual(credential?.id, testCredentialData.id)
+        XCTAssertEqual(credential?.format, testCredentialData.format)
+        XCTAssertEqual(credential?.payload, testCredentialData.credential)
+        XCTAssertEqual(credential?.credentialType, testCredentialData.type)
+        XCTAssertNotNil(credential?.disclosure)
+        // Additional assertions can be added as necessary to validate other parts of the Credential
+    }
+
 }


### PR DESCRIPTION
Fixes issue https://github.com/OWND-Project/OWND-Wallet-iOS/issues/9.

Fixed the issue where only certain credentials could be handled.
Specifically, `CredentialType` has been removed and the credential type is now simply expressed as a string.


Although it is unrelated to the above fix, an error related to SwiftFormat occurred during build process, so I reinstalled it to resolve it, and there are some differences related to that.
