### PR TITLE
Support x_509_san_dns client_id_scheme value

### DIFF
--- a/tw2023_wallet.xcodeproj/project.pbxproj
+++ b/tw2023_wallet.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		8BB513942B3BB69A00D4EFB3 /* AsynTestRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB513932B3BB69A00D4EFB3 /* AsynTestRunner.swift */; };
 		8BB513972B3BB88900D4EFB3 /* VCIMetadataUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB513962B3BB88900D4EFB3 /* VCIMetadataUtil.swift */; };
 		8BB513982B3BB88900D4EFB3 /* VCIMetadataUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB513962B3BB88900D4EFB3 /* VCIMetadataUtil.swift */; };
+		8BEE638F2C19A48D00821543 /* CertificateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A892975A2B3AA81C007315BE /* CertificateUtil.swift */; };
 		8BF745992B4FF85F000F74A9 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8BF745982B4FF85F000F74A9 /* JOSESwift */; };
 		A81087142B3B0AB3004425DE /* SDJwtUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81087132B3B0AB3004425DE /* SDJwtUtil.swift */; };
 		A81087182B3BBA0C004425DE /* ES256K.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81087172B3BBA0C004425DE /* ES256K.swift */; };
@@ -1556,6 +1557,7 @@
 				8B43AE322B3A5B880016CF83 /* VCIMetadataClientTests.swift in Sources */,
 				8B5C65912B515BC300D72289 /* JWTUtil.swift in Sources */,
 				A83039BE2B4E4229004139A7 /* CertificateUtilTest.swift in Sources */,
+				8BEE638F2C19A48D00821543 /* CertificateUtil.swift in Sources */,
 				A84AB70D2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift in Sources */,
 				8BB2BA7A2B4BC95700C668BA /* AuthenticationView.swift in Sources */,
 				8B5C659F2B552C2700D72289 /* VerificationArgs.swift in Sources */,

--- a/tw2023_wallet/Utils/CertificateUtil.swift
+++ b/tw2023_wallet/Utils/CertificateUtil.swift
@@ -277,43 +277,6 @@ func extractCertificateChain(url: String) -> ([X509Certificate?], [Data?]) {
     return (extractedCertificates, extractedDerCertificates)
 }
 
-func secKeyToP256PublicKey(secKey: SecKey) -> P256.Signing.PublicKey? {
-    // 公開鍵データをSecKeyから抽出
-    var error: Unmanaged<CFError>?
-    guard let publicKeyData = SecKeyCopyExternalRepresentation(secKey, &error) as Data? else {
-        print("Error extracting public key data: \(error!.takeRetainedValue() as Error)")
-        return nil
-    }
-
-    // 公開鍵データをP256.Signing.PublicKeyに変換
-    do {
-        let publicKey = try P256.Signing.PublicKey(rawRepresentation: publicKeyData)
-        return publicKey
-    }
-    catch {
-        print("Error creating P256.Signing.PublicKey: \(error)")
-        return nil
-    }
-}
-func secKeyToP256PrivateKey(secKey: SecKey) -> P256.Signing.PrivateKey? {
-    // 秘密鍵データをSecKeyから抽出
-    var error: Unmanaged<CFError>?
-    guard let privateKeyData = SecKeyCopyExternalRepresentation(secKey, &error) as Data? else {
-        print("Error extracting private key data: \(error!.takeRetainedValue() as Error)")
-        return nil
-    }
-
-    // 秘密鍵データをP256.Signing.PrivateKeyに変換
-    do {
-        let privateKey = try P256.Signing.PrivateKey(rawRepresentation: privateKeyData)
-        return privateKey
-    }
-    catch {
-        print("Error creating P256.Signing.PrivateKey: \(error)")
-        return nil
-    }
-}
-
 func createDistinguishedName(
     commonName: String, organizationName: String, localityName: String, stateOrProvinceName: String,
     countryName: String

--- a/tw2023_wallet/Utils/KeyPairUtil.swift
+++ b/tw2023_wallet/Utils/KeyPairUtil.swift
@@ -5,6 +5,7 @@
 //  Created by katsuyoshi ozaki on 2024/01/05.
 //
 
+import CryptoKit
 import Foundation
 
 enum KeyError: Error {
@@ -227,6 +228,14 @@ class KeyPairUtil {
                 print(error)
                 return false
         }
+    }
+
+    static func generateRandomP256KeyPair() -> (
+        privateKey: P256.Signing.PrivateKey, publicKey: P256.Signing.PublicKey
+    ) {
+        let privateKey = P256.Signing.PrivateKey()
+        let publicKey = privateKey.publicKey
+        return (privateKey, publicKey)
     }
 }
 

--- a/tw2023_walletTests/Signature/SignatureUitlTest.swift
+++ b/tw2023_walletTests/Signature/SignatureUitlTest.swift
@@ -180,7 +180,8 @@ final class SignatureUitlTests: XCTestCase {
     }
 
     func testConvertPemToX509Certificates() {
-        let result = try! SignatureUtil.convertPemToX509Certificates(pemChain: fullChain)
+        let result = try! SignatureUtil.convertPemWithDelimitersToX509Certificates(
+            pemChain: fullChain)
         XCTAssertTrue(result.count == 4)
     }
 
@@ -316,7 +317,8 @@ final class SignatureUitlTests: XCTestCase {
             8qn0dNW44bOwgeThpWOjzOoEeJBuv/c=
             -----END CERTIFICATE-----
             """
-        let chain = try! SignatureUtil.convertPemToX509Certificates(pemChain: pemChain)
+        let chain = try! SignatureUtil.convertPemWithDelimitersToX509Certificates(
+            pemChain: pemChain)
         XCTAssertTrue(try! SignatureUtil.validateCertificateChain(certificates: chain))
     }
 }

--- a/tw2023_walletTests/Utils/CertificateUtilTest.swift
+++ b/tw2023_walletTests/Utils/CertificateUtilTest.swift
@@ -5,6 +5,8 @@
 //  Created by katsuyoshi ozaki on 2023/12/26.
 //
 
+import CryptoKit
+import X509
 import XCTest
 
 @testable import tw2023_wallet
@@ -24,5 +26,54 @@ class CertificateUtilTests: XCTestCase {
         // XCTAssertEqual(result?.locality, expected.locality)
         // XCTAssertEqual(result?.state, expected.state)
         // XCTAssertEqual(result?.country, expected.country)
+    }
+
+    func generateRandomString(length: Int) -> String {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        let randomString = String((0..<length).map { _ in letters.randomElement()! })
+        return randomString
+    }
+
+    func testGenerateCertificate() {
+        let subjectKey = KeyPairUtil.generateRandomP256KeyPair()
+        let publicKey = Certificate.PublicKey(subjectKey.publicKey)
+
+        let issueKey = KeyPairUtil.generateRandomP256KeyPair()
+        let privateKey = Certificate.PrivateKey(issueKey.privateKey)
+
+        do {
+            let now = Date()
+            let notBefore = now
+            let notAfter = Calendar.current.date(byAdding: .year, value: 1, to: now)!
+
+            let subjectDistinguishedName = try createDistinguishedName(
+                commonName: "Example Subject",
+                organizationName: "Example Company A",
+                localityName: "City A",
+                stateOrProvinceName: "State A",
+                countryName: "Country A"
+            )
+
+            let issuerDistinguishdName = try createDistinguishedName(
+                commonName: "Example CA",
+                organizationName: "Example Company B",
+                localityName: "City B",
+                stateOrProvinceName: "State B",
+                countryName: "Country B"
+            )
+
+            let cert = generateCertificate(
+                subjectKey: publicKey, subjectDistinguishedName: subjectDistinguishedName,
+                issuerKey: privateKey, issuerDistinguishedName: issuerDistinguishdName,
+                notBefore: notBefore, notAfter: notAfter,
+                isCa: false,
+                subjectAlternativeName: ["www.example.com", "api.example.com"]
+            )
+
+            XCTAssertNotNil(cert, "Should not be nil")
+        }
+        catch {
+            XCTFail()
+        }
     }
 }

--- a/tw2023_walletTests/Utils/CertificateUtilTest.swift
+++ b/tw2023_walletTests/Utils/CertificateUtilTest.swift
@@ -28,12 +28,6 @@ class CertificateUtilTests: XCTestCase {
         // XCTAssertEqual(result?.country, expected.country)
     }
 
-    func generateRandomString(length: Int) -> String {
-        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        let randomString = String((0..<length).map { _ in letters.randomElement()! })
-        return randomString
-    }
-
     func testGenerateCertificate() {
         let subjectKey = KeyPairUtil.generateRandomP256KeyPair()
         let publicKey = Certificate.PublicKey(subjectKey.publicKey)


### PR DESCRIPTION
The following has been added:

- If client_id_scheme is `x509_san_dns`, validate the RequestObject according to the [x5c property definition](https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.6)

- Check that the client_id value is the value of the SAN item at the end of the server certificate

- Check that the client_id value is the same as `redirect_uri`

- Share the conversion from the string representation of the server certificate to the Swift API with the existing `x5u` processing