### PR TITLE
support un signed auth request

### DIFF
--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -317,9 +317,9 @@ final class OpenIdProviderTests: XCTestCase {
 
             let requestObj = authRequestProcessedData.requestObject
             let authRequest = authRequestProcessedData.authorizationRequest
-            idProvider.clientId = requestObj.clientId ?? authRequest.clientId
-            idProvider.responseMode = requestObj.responseMode ?? authRequest.responseMode
-            idProvider.nonce = requestObj.nonce ?? authRequest.nonce
+            idProvider.clientId = requestObj?.clientId ?? authRequest.clientId
+            idProvider.responseMode = requestObj?.responseMode ?? authRequest.responseMode
+            idProvider.nonce = requestObj?.nonce ?? authRequest.nonce
             idProvider.presentationDefinition = authRequestProcessedData.presentationDefinition
 
             try KeyPairUtil.generateSignVerifyKeyPair(alias: Constants.Cryptography.KEY_BINDING)


### PR DESCRIPTION
The following fixes were made to the processing of unsigned authorization requests:

- Determine whether the request or request_uri in the authorization request URL is signed or not
- If the request is signed, obtain parameters from the Request Object and deserialize them
- If the request is unsigned, obtain parameters from the query parameters and deserialize them