### PR TITLE
Fix redirection after vp

### DIFF
--- a/tw2023_wallet/tw2023_walletApp.swift
+++ b/tw2023_wallet/tw2023_walletApp.swift
@@ -27,6 +27,7 @@ struct tw2023_walletApp: App {
     @State private var credentialOffer: String? = nil
     @State private var isShowingOpenID4VP = false
     @State private var openID4VP: String? = nil
+    @State private var navigateToRedirectView = false
 
     @State private var sharingRequestModel = SharingRequestModel()
 
@@ -58,11 +59,38 @@ struct tw2023_walletApp: App {
                         isPresented: $isShowingOpenID4VP,
                         onDismiss: {
                             openID4VP = nil
+                            if let postResult = sharingRequestModel.postResult,
+                               let location = postResult.location {
+                                navigateToRedirectView.toggle()
+                            }
                         }
                     ) {
                         if let value = openID4VP {
                             SharingRequest(args: createOpenID4VPArgs(value: value)).environment(
                                 sharingRequestModel)
+                        }
+                        else {
+                            EmptyView()
+                        }
+                    }
+                    .fullScreenCover(
+                        isPresented: $navigateToRedirectView,
+                        onDismiss: {
+                            navigateToRedirectView = false
+                        }
+                    ) {
+                        // let (urlString, cookies) = getRedirectParameters()
+                        if let postResult = sharingRequestModel.postResult,
+                            let urlString = postResult.location
+                        {
+                            NavigationView {
+                                RedirectView(urlString: urlString, cookieStrings: [])
+                                    .navigationBarItems(
+                                        trailing: Button("close") {
+                                            navigateToRedirectView = false
+                                        }
+                                    )
+                            }
                         }
                         else {
                             EmptyView()

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -12,42 +12,18 @@ import XCTest
 class ConvertVpTokenResponseResponseTests: XCTestCase {
     var idProvider: OpenIdProvider!
 
-       override func setUp() {
-           super.setUp()
-           idProvider = OpenIdProvider(ProviderOption())
-       }
+    override func setUp() {
+        super.setUp()
+        idProvider = OpenIdProvider(ProviderOption())
+    }
 
-       func testConvertVpTokenResponseResponse_withValid200JSONResponse() throws {
-           // Given
-           let json = """
-           {
-               "redirect_uri": "https://example.com"
-           }
-           """.data(using: .utf8)!
-           let response = HTTPURLResponse(
-               url: URL(string: "https://example.com")!,
-               statusCode: 200,
-               httpVersion: nil,
-               headerFields: ["Content-Type": "application/json"]
-           )!
-           let requestURL = URL(string: "https://example.com")!
-           
-           // When
-           let result = try idProvider.convertVpTokenResponseResponse(data: json, response: response, requestURL: requestURL)
-           
-           // Then
-           XCTAssertEqual(result.statusCode, 200)
-           XCTAssertEqual(result.location, "https://example.com")
-           XCTAssertNil(result.cookies)
-       }
-       
-    func testConvertVpTokenResponseResponse_withInvalid200JSONResponse() throws {
+    func testConvertVpTokenResponseResponse_withValid200JSONResponse() throws {
         // Given
         let json = """
-           {
-               "invalid_key": "invalid_value"
-           }
-           """.data(using: .utf8)!
+            {
+                "redirect_uri": "https://example.com"
+            }
+            """.data(using: .utf8)!
         let response = HTTPURLResponse(
             url: URL(string: "https://example.com")!,
             statusCode: 200,
@@ -55,66 +31,96 @@ class ConvertVpTokenResponseResponseTests: XCTestCase {
             headerFields: ["Content-Type": "application/json"]
         )!
         let requestURL = URL(string: "https://example.com")!
-        
+
+        // When
+        let result = try idProvider.convertVpTokenResponseResponse(
+            data: json, response: response, requestURL: requestURL)
+
         // Then
-        let result = try idProvider.convertVpTokenResponseResponse(data: json, response: response, requestURL: requestURL)
+        XCTAssertEqual(result.statusCode, 200)
+        XCTAssertEqual(result.location, "https://example.com")
+        XCTAssertNil(result.cookies)
+    }
+
+    func testConvertVpTokenResponseResponse_withInvalid200JSONResponse() throws {
+        // Given
+        let json = """
+            {
+                "invalid_key": "invalid_value"
+            }
+            """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        let requestURL = URL(string: "https://example.com")!
+
+        // Then
+        let result = try idProvider.convertVpTokenResponseResponse(
+            data: json, response: response, requestURL: requestURL)
         XCTAssertEqual(result.statusCode, 200)
         XCTAssertNil(result.location)
         XCTAssertNil(result.cookies)
-        
+
     }
-       
-       func testConvertVpTokenResponseResponse_with302RedirectAbsoluteURL() throws {
-           // Given
-           let response = HTTPURLResponse(
-               url: URL(string: "https://example.com")!,
-               statusCode: 302,
-               httpVersion: nil,
-               headerFields: ["Location": "https://example.com"]
-           )!
-           let requestURL = URL(string: "https://example.com")!
-           
-           // When
-           let result = try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL)
-           
-           // Then
-           XCTAssertEqual(result.statusCode, 302)
-           XCTAssertEqual(result.location, "https://example.com")
-           XCTAssertNil(result.cookies)
-       }
-       
-       func testConvertVpTokenResponseResponse_with302RedirectRelativeURL() throws {
-           // Given
-           let response = HTTPURLResponse(
-               url: URL(string: "https://example.com")!,
-               statusCode: 302,
-               httpVersion: nil,
-               headerFields: ["Location": "/path/to/resource"]
-           )!
-           let requestURL = URL(string: "https://example.com")!
-           
-           // When
-           let result = try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL)
-           
-           // Then
-           XCTAssertEqual(result.statusCode, 302)
-           XCTAssertEqual(result.location, "https://example.com/path/to/resource")
-           XCTAssertNil(result.cookies)
-       }
-       
-       func testConvertVpTokenResponseResponse_with302RedirectMissingLocationHeader() throws {
-           // Given
-           let response = HTTPURLResponse(
-               url: URL(string: "https://example.com")!,
-               statusCode: 302,
-               httpVersion: nil,
-               headerFields: [:]
-           )!
-           let requestURL = URL(string: "https://example.com")!
-           
-           // Then
-           XCTAssertThrowsError(try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL))
-       }
+
+    func testConvertVpTokenResponseResponse_with302RedirectAbsoluteURL() throws {
+        // Given
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": "https://example.com"]
+        )!
+        let requestURL = URL(string: "https://example.com")!
+
+        // When
+        let result = try idProvider.convertVpTokenResponseResponse(
+            data: Data(), response: response, requestURL: requestURL)
+
+        // Then
+        XCTAssertEqual(result.statusCode, 302)
+        XCTAssertEqual(result.location, "https://example.com")
+        XCTAssertNil(result.cookies)
+    }
+
+    func testConvertVpTokenResponseResponse_with302RedirectRelativeURL() throws {
+        // Given
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: ["Location": "/path/to/resource"]
+        )!
+        let requestURL = URL(string: "https://example.com")!
+
+        // When
+        let result = try idProvider.convertVpTokenResponseResponse(
+            data: Data(), response: response, requestURL: requestURL)
+
+        // Then
+        XCTAssertEqual(result.statusCode, 302)
+        XCTAssertEqual(result.location, "https://example.com/path/to/resource")
+        XCTAssertNil(result.cookies)
+    }
+
+    func testConvertVpTokenResponseResponse_with302RedirectMissingLocationHeader() throws {
+        // Given
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: [:]
+        )!
+        let requestURL = URL(string: "https://example.com")!
+
+        // Then
+        XCTAssertThrowsError(
+            try idProvider.convertVpTokenResponseResponse(
+                data: Data(), response: response, requestURL: requestURL))
+    }
 }
 
 final class OpenIdProviderTests: XCTestCase {

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -9,6 +9,114 @@ import XCTest
 
 @testable import tw2023_wallet
 
+class ConvertVpTokenResponseResponseTests: XCTestCase {
+    var idProvider: OpenIdProvider!
+
+       override func setUp() {
+           super.setUp()
+           idProvider = OpenIdProvider(ProviderOption())
+       }
+
+       func testConvertVpTokenResponseResponse_withValid200JSONResponse() throws {
+           // Given
+           let json = """
+           {
+               "redirect_uri": "https://example.com"
+           }
+           """.data(using: .utf8)!
+           let response = HTTPURLResponse(
+               url: URL(string: "https://example.com")!,
+               statusCode: 200,
+               httpVersion: nil,
+               headerFields: ["Content-Type": "application/json"]
+           )!
+           let requestURL = URL(string: "https://example.com")!
+           
+           // When
+           let result = try idProvider.convertVpTokenResponseResponse(data: json, response: response, requestURL: requestURL)
+           
+           // Then
+           XCTAssertEqual(result.statusCode, 200)
+           XCTAssertEqual(result.location, "https://example.com")
+           XCTAssertNil(result.cookies)
+       }
+       
+    func testConvertVpTokenResponseResponse_withInvalid200JSONResponse() throws {
+        // Given
+        let json = """
+           {
+               "invalid_key": "invalid_value"
+           }
+           """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        let requestURL = URL(string: "https://example.com")!
+        
+        // Then
+        let result = try idProvider.convertVpTokenResponseResponse(data: json, response: response, requestURL: requestURL)
+        XCTAssertEqual(result.statusCode, 200)
+        XCTAssertNil(result.location)
+        XCTAssertNil(result.cookies)
+        
+    }
+       
+       func testConvertVpTokenResponseResponse_with302RedirectAbsoluteURL() throws {
+           // Given
+           let response = HTTPURLResponse(
+               url: URL(string: "https://example.com")!,
+               statusCode: 302,
+               httpVersion: nil,
+               headerFields: ["Location": "https://example.com"]
+           )!
+           let requestURL = URL(string: "https://example.com")!
+           
+           // When
+           let result = try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL)
+           
+           // Then
+           XCTAssertEqual(result.statusCode, 302)
+           XCTAssertEqual(result.location, "https://example.com")
+           XCTAssertNil(result.cookies)
+       }
+       
+       func testConvertVpTokenResponseResponse_with302RedirectRelativeURL() throws {
+           // Given
+           let response = HTTPURLResponse(
+               url: URL(string: "https://example.com")!,
+               statusCode: 302,
+               httpVersion: nil,
+               headerFields: ["Location": "/path/to/resource"]
+           )!
+           let requestURL = URL(string: "https://example.com")!
+           
+           // When
+           let result = try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL)
+           
+           // Then
+           XCTAssertEqual(result.statusCode, 302)
+           XCTAssertEqual(result.location, "https://example.com/path/to/resource")
+           XCTAssertNil(result.cookies)
+       }
+       
+       func testConvertVpTokenResponseResponse_with302RedirectMissingLocationHeader() throws {
+           // Given
+           let response = HTTPURLResponse(
+               url: URL(string: "https://example.com")!,
+               statusCode: 302,
+               httpVersion: nil,
+               headerFields: [:]
+           )!
+           let requestURL = URL(string: "https://example.com")!
+           
+           // Then
+           XCTAssertThrowsError(try idProvider.convertVpTokenResponseResponse(data: Data(), response: response, requestURL: requestURL))
+       }
+}
+
 final class OpenIdProviderTests: XCTestCase {
 
     override func setUpWithError() throws {

--- a/tw2023_walletTests/datastore/CredentialSharingHistoryManagerTest.swift
+++ b/tw2023_walletTests/datastore/CredentialSharingHistoryManagerTest.swift
@@ -64,7 +64,6 @@ class CredentialSharingHistoryManagerTests: XCTestCase {
         let fetchedHistory = savedHistories.first!
         XCTAssertEqual(fetchedHistory.rp, credentialSharingHistory.rp)
         XCTAssertEqual(fetchedHistory.accountIndex, credentialSharingHistory.accountIndex)
-        XCTAssertEqual(fetchedHistory.createdAt, credentialSharingHistory.createdAt)
         XCTAssertEqual(fetchedHistory.credentialID, credentialSharingHistory.credentialID)
 
         let set1 = NSSet(array: credentialSharingHistory.claims)


### PR DESCRIPTION
- Fixed a problem in which the redirect destination could not be obtained as expected when `Charset=UTF-8` is added to `Content-Type`. 
- Also, fixed to handle cases where the redirect destination is indicated in the 302 response.

- Fixed so that the redirect screen is launched after VP even if the app is launched in the same device flow.