### PR TITLE
Simultaneous sending tokens 431

### DIFF
--- a/tw2023_wallet.xcodeproj/project.pbxproj
+++ b/tw2023_wallet.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		8BB513982B3BB88900D4EFB3 /* VCIMetadataUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB513962B3BB88900D4EFB3 /* VCIMetadataUtil.swift */; };
 		8BEE638F2C19A48D00821543 /* CertificateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A892975A2B3AA81C007315BE /* CertificateUtil.swift */; };
 		8BF745992B4FF85F000F74A9 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8BF745982B4FF85F000F74A9 /* JOSESwift */; };
+		A80BFE762CAD070E00E30249 /* ProviderUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80BFE752CAD070A00E30249 /* ProviderUtils.swift */; };
+		A80BFE772CAD070E00E30249 /* ProviderUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80BFE752CAD070A00E30249 /* ProviderUtils.swift */; };
 		A81087142B3B0AB3004425DE /* SDJwtUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81087132B3B0AB3004425DE /* SDJwtUtil.swift */; };
 		A81087182B3BBA0C004425DE /* ES256K.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81087172B3BBA0C004425DE /* ES256K.swift */; };
 		A810871E2B3BC9DF004425DE /* ES256KTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A810871D2B3BC9DF004425DE /* ES256KTest.swift */; };
@@ -388,6 +390,7 @@
 		8BB513912B3BB4B900D4EFB3 /* VCIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCIClientTests.swift; sourceTree = "<group>"; };
 		8BB513932B3BB69A00D4EFB3 /* AsynTestRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsynTestRunner.swift; sourceTree = "<group>"; };
 		8BB513962B3BB88900D4EFB3 /* VCIMetadataUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCIMetadataUtil.swift; sourceTree = "<group>"; };
+		A80BFE752CAD070A00E30249 /* ProviderUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderUtils.swift; sourceTree = "<group>"; };
 		A80FFF322B7F3D300076718E /* SharingToViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingToViewModel.swift; sourceTree = "<group>"; };
 		A80FFF342B7F3D990076718E /* SharingToModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingToModel.swift; sourceTree = "<group>"; };
 		A81087132B3B0AB3004425DE /* SDJwtUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDJwtUtil.swift; sourceTree = "<group>"; };
@@ -1137,6 +1140,7 @@
 		A8C0A3C82CABCEA0008998C5 /* Provider */ = {
 			isa = PBXGroup;
 			children = (
+				A80BFE752CAD070A00E30249 /* ProviderUtils.swift */,
 				A87A957C2CACCDD000001D8F /* ProviderTypes.swift */,
 				A8C0A3D22CABD088008998C5 /* Errors.swift */,
 				8B6C3B832B45082A00B5D784 /* OpenIdProvider.swift */,
@@ -1687,6 +1691,7 @@
 				F657D5CF2B3C469500901A6A /* CredentialDetailModel.swift in Sources */,
 				8B4265952B564B2D00A07F2B /* IssuerDetailViewModel.swift in Sources */,
 				A84AB6F42B50111500E8C88B /* id_token_sharing_history.pb.swift in Sources */,
+				A80BFE772CAD070E00E30249 /* ProviderUtils.swift in Sources */,
 				8B6C3B842B45082A00B5D784 /* OpenIdProvider.swift in Sources */,
 				8B56254B2B7073CB00D6D28B /* RedirectView.swift in Sources */,
 				8B81E2DC2B3420A400ED3B4E /* CredentialRow.swift in Sources */,
@@ -1723,6 +1728,7 @@
 				8B81E2AE2B33CC4300ED3B4E /* tw2023_walletTests.swift in Sources */,
 				A810871E2B3BC9DF004425DE /* ES256KTest.swift in Sources */,
 				8B297C382B3953D700D2998D /* VCIMetadata.swift in Sources */,
+				A80BFE762CAD070E00E30249 /* ProviderUtils.swift in Sources */,
 				8BAB8D8B2C0F128100B579A4 /* JwtVpJsonGeneratorImpl.swift in Sources */,
 				8B297C372B39538500D2998D /* VCIMetadataTests.swift in Sources */,
 				8BAB8D8C2C10045300B579A4 /* Constants.swift in Sources */,

--- a/tw2023_wallet.xcodeproj/project.pbxproj
+++ b/tw2023_wallet.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		A8ADC69B2BCEAD090077A0C4 /* idTokenSharingHistories.json in Resources */ = {isa = PBXBuildFile; fileRef = A8ADC69A2BCEAD090077A0C4 /* idTokenSharingHistories.json */; };
 		A8AF22882C12A59B00D6EDA5 /* RestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF22872C12A59B00D6EDA5 /* RestoreHelper.swift */; };
 		A8AF228D2C12A6C100D6EDA5 /* RestoreHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF228C2C12A6C100D6EDA5 /* RestoreHelperTests.swift */; };
+		A8C0A3D32CABD088008998C5 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C0A3D22CABD088008998C5 /* Errors.swift */; };
+		A8C0A3D42CABD089008998C5 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C0A3D22CABD088008998C5 /* Errors.swift */; };
 		A8C810422B82042300CF8CD6 /* SharingToViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C8103C2B82042200CF8CD6 /* SharingToViewModel.swift */; };
 		A8C810432B82042300CF8CD6 /* SharingToModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C8103E2B82042200CF8CD6 /* SharingToModel.swift */; };
 		A8C810442B82042300CF8CD6 /* SharingToRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C810402B82042200CF8CD6 /* SharingToRow.swift */; };
@@ -441,6 +443,7 @@
 		A8ADC69A2BCEAD090077A0C4 /* idTokenSharingHistories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = idTokenSharingHistories.json; sourceTree = "<group>"; };
 		A8AF22872C12A59B00D6EDA5 /* RestoreHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreHelper.swift; sourceTree = "<group>"; };
 		A8AF228C2C12A6C100D6EDA5 /* RestoreHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreHelperTests.swift; sourceTree = "<group>"; };
+		A8C0A3D22CABD088008998C5 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		A8C810382B80951800CF8CD6 /* SharingToRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingToRow.swift; sourceTree = "<group>"; };
 		A8C8103C2B82042200CF8CD6 /* SharingToViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingToViewModel.swift; sourceTree = "<group>"; };
 		A8C8103E2B82042200CF8CD6 /* SharingToModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingToModel.swift; sourceTree = "<group>"; };
@@ -583,12 +586,12 @@
 		8B297C322B393B6700D2998D /* OID */ = {
 			isa = PBXGroup;
 			children = (
+				A8C0A3C82CABCEA0008998C5 /* Provider */,
 				8B297C352B393BC800D2998D /* VCI */,
 				8B43AE332B3A81960016CF83 /* Enums.swift */,
 				8B43AE362B3A93C60016CF83 /* AuthServerMetadata.swift */,
 				8B0E0AA52B3ED4860080F6A3 /* AuthorizationRequest.swift */,
 				8B0E0AAE2B403D510080F6A3 /* PresentationExchange.swift */,
-				8B6C3B832B45082A00B5D784 /* OpenIdProvider.swift */,
 				8B5C65942B5237C200D72289 /* Types.swift */,
 				8B5C65972B5251C000D72289 /* KeyBindingImpl.swift */,
 				8BAB8D892C0F128100B579A4 /* JwtVpJsonGeneratorImpl.swift */,
@@ -1128,6 +1131,15 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		A8C0A3C82CABCEA0008998C5 /* Provider */ = {
+			isa = PBXGroup;
+			children = (
+				A8C0A3D22CABD088008998C5 /* Errors.swift */,
+				8B6C3B832B45082A00B5D784 /* OpenIdProvider.swift */,
+			);
+			path = Provider;
+			sourceTree = "<group>";
+		};
 		A8C8103A2B82042200CF8CD6 /* SharingTo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1630,6 +1642,7 @@
 				F6CC76932B567BDF00FA26A8 /* QRReaderViewModel.swift in Sources */,
 				8BB2BA742B4BC46400C668BA /* BiometricAuth.swift in Sources */,
 				F6CB1FAE2B68FB180078C857 /* DateFormatterUtil.swift in Sources */,
+				A8C0A3D42CABD089008998C5 /* Errors.swift in Sources */,
 				8B81E29D2B33CC4000ED3B4E /* tw2023_walletApp.swift in Sources */,
 				8B81E2E92B3451DC00ED3B4E /* FloatingActionButton.swift in Sources */,
 				A8AF22882C12A59B00D6EDA5 /* RestoreHelper.swift in Sources */,
@@ -1743,6 +1756,7 @@
 				A83039BD2B4E4229004139A7 /* JWTTest.swift in Sources */,
 				8B6C3B892B481BEC00B5D784 /* VCIMetadataUtilTests.swift in Sources */,
 				8B0E0AA02B3D69240080F6A3 /* PairwiseAccount.swift in Sources */,
+				A8C0A3D32CABD088008998C5 /* Errors.swift in Sources */,
 				A88D323A2C26997700429E75 /* Metadata.swift in Sources */,
 				8BB513982B3BB88900D4EFB3 /* VCIMetadataUtil.swift in Sources */,
 				8B43AE382B3A93C60016CF83 /* AuthServerMetadata.swift in Sources */,

--- a/tw2023_wallet.xcodeproj/project.pbxproj
+++ b/tw2023_wallet.xcodeproj/project.pbxproj
@@ -174,6 +174,8 @@
 		A84AB70D2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84AB70C2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift */; };
 		A8509C292B82315D00B28C35 /* RecipientClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509C282B82315D00B28C35 /* RecipientClaims.swift */; };
 		A857C25A2C0DD3200059A82F /* swift-format in Frameworks */ = {isa = PBXBuildFile; productRef = A857C2592C0DD3200059A82F /* swift-format */; };
+		A87A957D2CACCDD500001D8F /* ProviderTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87A957C2CACCDD000001D8F /* ProviderTypes.swift */; };
+		A87A957E2CACCDD500001D8F /* ProviderTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87A957C2CACCDD000001D8F /* ProviderTypes.swift */; };
 		A88779BD2C33DC08002EE9C2 /* WebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88779BC2C33DC08002EE9C2 /* WebViewTests.swift */; };
 		A88D323A2C26997700429E75 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82ECC782C22738900B9784B /* Metadata.swift */; };
 		A88D323C2C26B0DF00429E75 /* UrlEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82ECC7F2C23A6AB00B9784B /* UrlEncoder.swift */; };
@@ -422,6 +424,7 @@
 		A84AB70A2B50B98C00E8C88B /* CredentialSharingHistoryManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialSharingHistoryManagerTest.swift; sourceTree = "<group>"; };
 		A84AB70C2B50C2DD00E8C88B /* IdTokenSharingHistoryManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenSharingHistoryManagerTest.swift; sourceTree = "<group>"; };
 		A8509C282B82315D00B28C35 /* RecipientClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipientClaims.swift; sourceTree = "<group>"; };
+		A87A957C2CACCDD000001D8F /* ProviderTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderTypes.swift; sourceTree = "<group>"; };
 		A88779BC2C33DC08002EE9C2 /* WebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewTests.swift; sourceTree = "<group>"; };
 		A89108012B82D1650060DD71 /* RecipientClaimsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipientClaimsViewModel.swift; sourceTree = "<group>"; };
 		A89108032B82D2880060DD71 /* RecipientClaimsPreviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipientClaimsPreviewModel.swift; sourceTree = "<group>"; };
@@ -1134,6 +1137,7 @@
 		A8C0A3C82CABCEA0008998C5 /* Provider */ = {
 			isa = PBXGroup;
 			children = (
+				A87A957C2CACCDD000001D8F /* ProviderTypes.swift */,
 				A8C0A3D22CABD088008998C5 /* Errors.swift */,
 				8B6C3B832B45082A00B5D784 /* OpenIdProvider.swift */,
 			);
@@ -1605,6 +1609,7 @@
 				8B4CAB672B7F4D440006FF4D /* Restore.swift in Sources */,
 				8B81E2F02B3546BC00ED3B4E /* SharingRequest.swift in Sources */,
 				8B43AE2F2B3A5B2C0016CF83 /* MockURLProtocol.swift in Sources */,
+				A87A957D2CACCDD500001D8F /* ProviderTypes.swift in Sources */,
 				8B81E2C82B33D6C500ED3B4E /* Home.swift in Sources */,
 				A8ADC6992BCE3CDA0077A0C4 /* IdTokenSharingHistory.swift in Sources */,
 				8B0E0AAF2B403D510080F6A3 /* PresentationExchange.swift in Sources */,
@@ -1721,6 +1726,7 @@
 				8BAB8D8B2C0F128100B579A4 /* JwtVpJsonGeneratorImpl.swift in Sources */,
 				8B297C372B39538500D2998D /* VCIMetadataTests.swift in Sources */,
 				8BAB8D8C2C10045300B579A4 /* Constants.swift in Sources */,
+				A87A957E2CACCDD500001D8F /* ProviderTypes.swift in Sources */,
 				8B6C3B872B47BED600B5D784 /* OpenIdProviderTests.swift in Sources */,
 				8B0E0A982B3BC39C0080F6A3 /* KeyRing.swift in Sources */,
 				8BB2BA7D2B4C08D900C668BA /* EncryptionHelper.swift in Sources */,

--- a/tw2023_wallet/Feature/Credentials/ViewModels/CredentialDetailViewModel.swift
+++ b/tw2023_wallet/Feature/Credentials/ViewModels/CredentialDetailViewModel.swift
@@ -34,8 +34,8 @@ class CredentialDetailViewModel {
         if let pd = presentationDefinition {
             switch credential.format {
                 case "vc+sd-jwt":
-                    if let matched = matchVcToRequirement(
-                        sdJwt: credential.payload, presentationDefinition: pd)
+                    if let matched = pd.matchSdJwtVcToRequirement(
+                        sdJwt: credential.payload)
                     {
                         let (inputDescriptors, disclosuresWithOptionality) = matched
                         self.inputDescriptor = inputDescriptors

--- a/tw2023_wallet/Feature/Credentials/ViewModels/CredentialListViewModel.swift
+++ b/tw2023_wallet/Feature/Credentials/ViewModels/CredentialListViewModel.swift
@@ -51,8 +51,8 @@ class CredentialListViewModel {
         print("format: \(format)")
         do {
             if format == "vc+sd-jwt" {
-                let ret = matchVcToRequirement(
-                    sdJwt: credential.payload, presentationDefinition: presentationDefinition)
+                let ret = presentationDefinition.matchSdJwtVcToRequirement(
+                    sdJwt: credential.payload)
                 if let (_, disclosures) = ret {
                     return 0
                         < disclosures.filter { it in (it.isUserSelectable || it.isSubmit) }.count
@@ -62,8 +62,8 @@ class CredentialListViewModel {
             else if format == "jwt_vc_json" {
                 let (_, payload, _) = try JWTUtil.decodeJwt(jwt: credential.payload)
                 print("satisfyConstrains?")
-                return satisfyConstrains(
-                    credential: payload, presentationDefinition: presentationDefinition)
+                return presentationDefinition.satisfyConstrains(
+                    credential: payload)
             }
             else {
                 // その他のフォーマットに対する処理が必要な場合、ここに追加

--- a/tw2023_wallet/Feature/ShareCredential/Models/SharingRequesModel.swift
+++ b/tw2023_wallet/Feature/ShareCredential/Models/SharingRequesModel.swift
@@ -10,7 +10,7 @@ import Foundation
 @Observable
 class SharingRequestModel {
     var redirectTo: String? = nil
-    var postResult: PostResult? = nil
+    var postResult: TokenSendResult? = nil
     var presentationDefinition: PresentationDefinition? = nil
     init(presentationDefinition: PresentationDefinition? = nil) {
         self.presentationDefinition = presentationDefinition

--- a/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
+++ b/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
@@ -74,7 +74,7 @@ class SharingRequestViewModel {
         openIdProvider = OpenIdProvider(ProviderOption())
         do {
             print("process SIOP Request")
-            let result = await openIdProvider?.processSIOPRequest(url)
+            let result = await openIdProvider?.processAuthRequest(url)
             switch result {
                 case .success(let processedRequestData):
                     // gen client info

--- a/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
+++ b/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
@@ -209,7 +209,10 @@ class SharingRequestViewModel {
             print("\(errorState): Initialization Failed")
             return .failure(errorState)
         }
-        openIdProvider.setSiopAccount(account: account, accountManager: accountManager)
+        let publicKey = accountManager.getPublicKey(index: account.index)
+        let privateKey = accountManager.getPrivateKey(index: account.index)
+        let keyPair = KeyPairData(publicKey: publicKey, privateKey: privateKey)
+        openIdProvider.setSecp256k1KeyPair(keyPair: keyPair)
 
         print("Start initialization process to send vp_token")
         let keyBinding = KeyBindingImpl(keyAlias: Constants.Cryptography.KEY_BINDING)

--- a/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
+++ b/tw2023_wallet/Feature/ShareCredential/ViewModels/SharingRequestViewModel.swift
@@ -192,8 +192,8 @@ class SharingRequestViewModel {
         return idTokenSharingHistories
     }
 
-    func shareIdToken() async -> Result<TokenSendResult, Error> {
-        print("share id token")
+    func shareToken(credentials: [SubmissionCredential]?) async -> Result<TokenSendResult, Error> {
+        print("Start initialization process to send id_token")
         guard let openIdProvider = openIdProvider,
             let account = account,
             let seed = seed,
@@ -209,47 +209,9 @@ class SharingRequestViewModel {
             print("\(errorState): Initialization Failed")
             return .failure(errorState)
         }
+        openIdProvider.setSiopAccount(account: account, accountManager: accountManager)
 
-        let publicKey = accountManager.getPublicKey(index: account.index)
-        let privateKey = accountManager.getPrivateKey(index: account.index)
-
-        let keyPair = KeyPairData(publicKey: publicKey, privateKey: privateKey)
-        openIdProvider.setSecp256k1KeyPair(keyPair: keyPair)
-
-        let delegate = NoRedirectDelegate()
-        let configuration = URLSessionConfiguration.default
-        let session = URLSession(
-            configuration: configuration, delegate: delegate, delegateQueue: nil)
-
-        let result = await openIdProvider.respondSIOPResponse(using: session)
-        switch result {
-            case .success(let postResult):
-                print("save history")
-                let storeManager = IdTokenSharingHistoryManager(container: nil)
-                var history = Datastore_IdTokenSharingHistory()
-                history.rp = openIdProvider.clientId!
-                // history.rp = openIdProvider.authRequestProcessedData?.clientMetadata.clientId ?? ""
-                history.accountIndex = Int32(account.index)
-                history.createdAt = Date().toGoogleTimestamp()
-                storeManager.save(history: history)
-                return .success(postResult)
-            case .failure(let error):
-                print("Response Error: \(error)")
-                return .failure(error)
-        }
-    }
-
-    func shareVpToken(credentials: [SubmissionCredential]) async -> Result<TokenSendResult, Error> {
-        print("share vp token")
-        guard let openIdProvider = openIdProvider,
-            let account = account,
-            let _ = seed
-        else {
-            let errorState = SharingRequestIllegalStateException.illegalState
-            print("\(errorState): Initialization Failed")
-            return .failure(errorState)
-        }
-        print("get keypair")
+        print("Start initialization process to send vp_token")
         let keyBinding = KeyBindingImpl(keyAlias: Constants.Cryptography.KEY_BINDING)
         openIdProvider.setKeyBinding(keyBinding: keyBinding)
 
@@ -257,46 +219,60 @@ class SharingRequestViewModel {
             keyAlias: Constants.Cryptography.KEY_PAIR_ALIAS_FOR_KEY_JWT_VP_JSON)
         openIdProvider.setJwtVpJsonGenerator(jwtVpJsonGenerator: jwtVpJsonGenerator)
 
+        print("Start initialization process for accessing network")
         let delegate = NoRedirectDelegate()
         let configuration = URLSessionConfiguration.default
         let session = URLSession(
             configuration: configuration, delegate: delegate, delegateQueue: nil)
-        let result = await openIdProvider.respondVPResponse(
-            credentials: credentials, using: session)
+
+        print("Responding to verifier")
+        let result = await openIdProvider.respondToken(credentials: credentials, using: session)
         switch result {
-            case .success(let sharedResult):
-                print("sharing sucess")
-                let storeManager = CredentialSharingHistoryManager(container: nil)
-                guard let sharedContents = sharedResult.sharedContents else {
-                    return .failure(SharingRequestIllegalStateException.illegalSharedResult)
+            case .success(let postResult):
+                print("Saving hitories")
+                if let sharedCredentials = postResult.sharedCredentials {
+                    print("Saving vp token history")
+                    let storeManager = CredentialSharingHistoryManager(container: nil)
+                    for content in sharedCredentials {
+                        var history = Datastore_CredentialSharingHistory()
+                        history.accountIndex = Int32(account.index)
+                        history.createdAt = Date().toGoogleTimestamp()
+                        history.credentialID = content.id
+                        for (_, claim) in content.sharedClaims.enumerated() {
+                            var claimInfo = Datastore_ClaimInfo()
+                            claimInfo.claimKey = claim.name
+                            claimInfo.claimValue = claim.value ?? ""
+                            claimInfo.purpose = content.purposeForSharing ?? ""
+                            history.claims.append(
+                                claimInfo
+                            )
+                        }
+                        let metadata = openIdProvider.authRequestProcessedData?.clientMetadata
+                        history.rp = metadata?.clientId ?? ""
+                        history.rpName = metadata?.clientName ?? ""
+                        history.privacyPolicyURL = metadata?.policyUri ?? ""
+                        history.logoURL = metadata?.logoUri ?? ""
+
+                        storeManager.save(history: history)
+                    }
+
                 }
-                for content in sharedContents {
-                    var history = Datastore_CredentialSharingHistory()
+
+                if postResult.sharedIdToken != nil {
+                    print("Saving id token history")
+                    let storeManager = IdTokenSharingHistoryManager(container: nil)
+                    var history = Datastore_IdTokenSharingHistory()
+                    history.rp = openIdProvider.clientId!
                     history.accountIndex = Int32(account.index)
                     history.createdAt = Date().toGoogleTimestamp()
-                    history.credentialID = content.id
-                    for (index, claim) in content.sharedClaims.enumerated() {
-                        var claimInfo = Datastore_ClaimInfo()
-                        claimInfo.claimKey = claim.name
-                        claimInfo.claimValue = claim.value ?? ""
-                        claimInfo.purpose = content.sharedPurpose ?? ""
-                        history.claims.append(
-                            claimInfo
-                        )
-                    }
-                    let metadata = openIdProvider.authRequestProcessedData?.clientMetadata
-                    history.rp = metadata?.clientId ?? ""
-                    history.rpName = metadata?.clientName ?? ""
-                    history.privacyPolicyURL = metadata?.policyUri ?? ""
-                    history.logoURL = metadata?.logoUri ?? ""
-
                     storeManager.save(history: history)
                 }
-                return .success(sharedResult)
+                return .success(postResult)
             case .failure(let error):
                 print("Response Error: \(error)")
                 return .failure(error)
         }
+
     }
 
     enum ShareIdTokenError: Error {

--- a/tw2023_wallet/Feature/ShareCredential/Views/SharingRequest.swift
+++ b/tw2023_wallet/Feature/ShareCredential/Views/SharingRequest.swift
@@ -155,47 +155,23 @@ struct SharingRequest: View {
                                             title: "provide_information",
                                             action: {
                                                 Task {
-                                                    if viewModel.presentationDefinition != nil,
-                                                        viewModel.selectedCredential
-                                                    {
-                                                        let result = await viewModel.shareVpToken(
-                                                            credentials: sharingRequestModel.data!
-                                                        )
-                                                        switch result {
-                                                            case .success(let postResult):
-                                                                print("VP Token sharing succeeded.")
-                                                                if postResult.location != nil {
-                                                                    sharingRequestModel.postResult =
-                                                                        postResult
-                                                                }
-                                                                showAlert = true
-                                                                alertTitle =
-                                                                    "VP Token sharing succeeded."
-                                                            case .failure(let error):
-                                                                print(
-                                                                    "VP Token sharing failed with error: \(error)"
-                                                                )
-                                                                showAlert = true
-                                                        }
-                                                    }
-                                                    else {
-                                                        let result = await viewModel.shareIdToken()
-                                                        switch result {
-                                                            case .success(let postResult):
-                                                                print("ID Token sharing succeeded.")
-                                                                if postResult.location != nil {
-                                                                    sharingRequestModel.postResult =
-                                                                        postResult
-                                                                }
-                                                                showAlert = true
-                                                                alertTitle =
-                                                                    "ID Token sharing succeeded."
-                                                            case .failure(let error):
-                                                                print(
-                                                                    "ID Token sharing failed with error: \(error)"
-                                                                )
-                                                                showAlert = true
-                                                        }
+                                                    let result = await viewModel.shareToken(
+                                                        credentials: sharingRequestModel.data)
+                                                    switch result {
+                                                        case .success(let postResult):
+                                                            print("Token sharing succeeded.")
+                                                            if postResult.location != nil {
+                                                                sharingRequestModel.postResult =
+                                                                    postResult
+                                                            }
+                                                            showAlert = true
+                                                            alertTitle =
+                                                                "Token sharing succeeded."
+                                                        case .failure(let error):
+                                                            print(
+                                                                "Token sharing failed with error: \(error)"
+                                                            )
+                                                            showAlert = true
                                                     }
                                                 }
                                             }

--- a/tw2023_wallet/Services/OID/Provider/Errors.swift
+++ b/tw2023_wallet/Services/OID/Provider/Errors.swift
@@ -1,0 +1,46 @@
+//
+//  Errors.swift
+//  tw2023_wallet
+//
+//  Created by katsuyoshi ozaki on 2024/10/01.
+//
+
+enum NetworkError: Error {
+    case invalidResponse
+    case statusCodeNotSuccessful(Int)
+    case decodingError
+    case other(Error)
+}
+
+enum OpenIdProviderRequestException: Error {
+    case badAuthRequest
+    // already consumed request, failed to get client additinal info(request jwt, client metada, etc), etc
+    case unavailableAuthRequest
+    case validateRequestJwtFailure
+}
+
+enum OpenIdProviderIllegalInputException: Error {
+    case illegalClientIdInput
+    case illegalJsonInputInput
+    case illegalResponseTypeInput
+    case illegalResponseModeInput
+    case illegalNonceInput
+    case illegalPresentationDefinitionInput
+    case illegalRedirectUriInput
+    case illegalDisclosureInput
+    case illegalCredentialInput
+}
+
+enum OpenIdProviderIllegalStateException: Error {
+    case illegalAuthRequestProcessedDataState
+    case illegalClientIdState
+    case illegalResponseModeState
+    case illegalNonceState
+    case illegalPresentationDefinitionState
+    case illegalRedirectUriState
+    case illegalKeypairState
+    case illegalKeyBindingState
+    case illegalJwkThumbprintState
+    case illegalJsonState
+    case illegalState
+}

--- a/tw2023_wallet/Services/OID/Provider/Errors.swift
+++ b/tw2023_wallet/Services/OID/Provider/Errors.swift
@@ -35,6 +35,7 @@ enum OpenIdProviderIllegalStateException: Error {
     case illegalAuthRequestProcessedDataState
     case illegalClientIdState
     case illegalResponseModeState
+    case illegalResponseTypeState
     case illegalNonceState
     case illegalPresentationDefinitionState
     case illegalRedirectUriState
@@ -43,4 +44,5 @@ enum OpenIdProviderIllegalStateException: Error {
     case illegalJwkThumbprintState
     case illegalJsonState
     case illegalState
+    case illegalAccountState
 }

--- a/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
+++ b/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
@@ -14,38 +14,7 @@ struct ProviderOption {
     let expiresIn: Int64 = 600
 }
 
-enum OpenIdProviderRequestException: Error {
-    case badAuthRequest
-    // already consumed request, failed to get client additinal info(request jwt, client metada, etc), etc
-    case unavailableAuthRequest
-    case validateRequestJwtFailure
-}
 
-enum OpenIdProviderIllegalInputException: Error {
-    case illegalClientIdInput
-    case illegalJsonInputInput
-    case illegalResponseTypeInput
-    case illegalResponseModeInput
-    case illegalNonceInput
-    case illegalPresentationDefinitionInput
-    case illegalRedirectUriInput
-    case illegalDisclosureInput
-    case illegalCredentialInput
-}
-
-enum OpenIdProviderIllegalStateException: Error {
-    case illegalAuthRequestProcessedDataState
-    case illegalClientIdState
-    case illegalResponseModeState
-    case illegalNonceState
-    case illegalPresentationDefinitionState
-    case illegalRedirectUriState
-    case illegalKeypairState
-    case illegalKeyBindingState
-    case illegalJwkThumbprintState
-    case illegalJsonState
-    case illegalState
-}
 
 class OpenIdProvider {
     private var option: ProviderOption
@@ -622,12 +591,6 @@ class OpenIdProvider {
     }
 }
 
-enum NetworkError: Error {
-    case invalidResponse
-    case statusCodeNotSuccessful(Int)
-    case decodingError
-    case other(Error)
-}
 
 func sendRequest<T: Decodable>(
     formData: [String: String],
@@ -738,11 +701,6 @@ struct SharedContent: Codable {
     let sharedClaims: [DisclosedClaim]
 }
 
-struct Triple<A, B, C> {
-    let first: A
-    let second: B
-    let third: C
-}
 
 func satisfyConstrains(credential: [String: Any], presentationDefinition: PresentationDefinition)
     -> Bool

--- a/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
+++ b/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
@@ -54,7 +54,7 @@ class OpenIdProvider {
         self.jwtVpJsonGenerator = jwtVpJsonGenerator
     }
 
-    func processSIOPRequest(_ url: String, using session: URLSession = URLSession.shared) async
+    func processAuthRequest(_ url: String, using session: URLSession = URLSession.shared) async
         -> Result<ProcessedRequestData, AuthorizationRequestError>
     {
         print("parseAndResolve")

--- a/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
+++ b/tw2023_wallet/Services/OID/Provider/OpenIdProvider.swift
@@ -21,8 +21,7 @@ class NoRedirectDelegate: NSObject, URLSessionTaskDelegate {
 
 class OpenIdProvider {
     private var option: ProviderOption
-    private var keyPair: KeyPair?  // for proof of posession for jwt_vc_json presentation
-    private var secp256k1KeyPair: KeyPairData?
+    private var secp256k1KeyPair: KeyPairData?  // for sub of id_token
     private var keyBinding: KeyBinding?
     private var jwtVpJsonGenerator: JwtVpJsonGenerator?
     var authRequestProcessedData: ProcessedRequestData?
@@ -37,10 +36,6 @@ class OpenIdProvider {
 
     init(_ option: ProviderOption) {
         self.option = option
-    }
-
-    func setKeyPair(keyPair: KeyPair) {
-        self.keyPair = keyPair
     }
 
     func setSecp256k1KeyPair(keyPair: KeyPairData) {

--- a/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
@@ -11,10 +11,26 @@ struct ProviderOption {
     let expiresIn: Int64 = 600
 }
 
-struct PostResult: Decodable {
+struct DisclosedClaim: Codable {
+    let id: String  // credential identifier
+    let types: [String]
+    let name: String
+    let value: String?
+    // let path: String   // when nested claim is supported, it may be needed
+}
+
+struct SharedContent: Codable {
+    let id: String
+    let sharedPurpose: String?
+    let sharedClaims: [DisclosedClaim]
+}
+
+struct TokenSendResult: Decodable {
     let statusCode: Int
     let location: String?
     let cookies: [String]?
+
+    let sharedContents: [SharedContent]?
 }
 
 struct PreparedSubmissionData {
@@ -135,17 +151,4 @@ struct SubmissionCredential: Codable, Equatable {
         }
     }
 
-}
-
-struct DisclosedClaim: Codable {
-    let id: String  // credential identifier
-    let types: [String]
-    let name: String
-    let value: String?
-    // let path: String   // when nested claim is supported, it may be needed
-}
-
-struct SharedContent: Codable {
-    let id: String
-    let sharedClaims: [DisclosedClaim]
 }

--- a/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
@@ -18,6 +18,7 @@ struct PostResult: Decodable {
 }
 
 struct PreparedSubmissionData {
+    let credentialId: String
     let vpToken: String
     let descriptorMap: DescriptorMap
     let disclosedClaims: [DisclosedClaim]
@@ -87,6 +88,7 @@ struct SubmissionCredential: Codable, Equatable {
         }
 
         return PreparedSubmissionData(
+            credentialId: id,
             vpToken: vpToken, descriptorMap: dm, disclosedClaims: disclosedClaims,
             purpose: inputDescriptor.purpose)
     }
@@ -116,6 +118,7 @@ struct SubmissionCredential: Codable, Equatable {
                 let descriptorMap = JwtVpJsonPresentation.genDescriptorMap(
                     inputDescriptorId: inputDescriptor.id)
                 return PreparedSubmissionData(
+                    credentialId: id,
                     vpToken: vpToken,
                     descriptorMap: descriptorMap,
                     disclosedClaims: disclosedClaims,

--- a/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
@@ -1,0 +1,51 @@
+//
+//  ProviderTypes.swift
+//  tw2023_wallet
+//
+//  Created by katsuyoshi ozaki on 2024/10/02.
+//
+
+struct ProviderOption {
+    let signingCurve: String = "secp256k1"
+    let signingAlgo: String = "ES256K"
+    let expiresIn: Int64 = 600
+}
+
+struct PostResult: Decodable {
+    let statusCode: Int
+    let location: String?
+    let cookies: [String]?
+}
+
+struct PreparedSubmissionData {
+    let vpToken: String
+    let descriptorMap: DescriptorMap
+    let disclosedClaims: [DisclosedClaim]
+    let purpose: String?
+}
+
+struct SubmissionCredential: Codable, Equatable {
+    let id: String
+    let format: String
+    let types: [String]
+    let credential: String
+    let inputDescriptor: InputDescriptor
+    let discloseClaims: [DisclosureWithOptionality]
+
+    static func == (lhs: SubmissionCredential, rhs: SubmissionCredential) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+struct DisclosedClaim: Codable {
+    let id: String  // credential identifier
+    let types: [String]
+    let name: String
+    let value: String?
+    // let path: String   // when nested claim is supported, it may be needed
+}
+
+struct SharedContent: Codable {
+    let id: String
+    let sharedClaims: [DisclosedClaim]
+}

--- a/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
@@ -35,6 +35,103 @@ struct SubmissionCredential: Codable, Equatable {
     static func == (lhs: SubmissionCredential, rhs: SubmissionCredential) -> Bool {
         return lhs.id == rhs.id
     }
+
+    func createVpTokenForSdJwtVc(
+        clientId: String,
+        nonce: String,
+        keyBinding: KeyBinding?
+    ) throws -> PreparedSubmissionData {
+        guard let kb = keyBinding else {
+            throw OpenIdProviderIllegalStateException.illegalKeyBindingState
+        }
+        // ここに実装を追加します
+        let inputDescriptor = inputDescriptor
+        let selectedDisclosures = discloseClaims.map { $0.disclosure }
+        print(String(describing: inputDescriptor))
+
+        let keyBindingJwt = try kb.generateJwt(
+            sdJwt: credential, selectedDisclosures: selectedDisclosures, aud: clientId, nonce: nonce
+        )
+
+        let parts = credential.split(separator: "~").map(String.init)
+        guard let issuerSignedJwt = parts.first else {
+            throw OpenIdProviderIllegalInputException.illegalCredentialInput
+        }
+
+        let hasNilValue = selectedDisclosures.contains { disclosure in
+            disclosure.disclosure == nil
+        }
+
+        if hasNilValue {
+            throw OpenIdProviderIllegalInputException.illegalDisclosureInput
+        }
+
+        let vpToken =
+            issuerSignedJwt + "~"
+            + selectedDisclosures.map { $0.disclosure! }.joined(separator: "~") + "~"
+            + keyBindingJwt
+
+        print("### Created vpToken\n\(vpToken)")
+
+        let dm = DescriptorMap(
+            id: inputDescriptor.id,
+            format: format,
+            path: "$",
+            pathNested: nil
+        )
+
+        let disclosedClaims = selectedDisclosures.compactMap { disclosure -> DisclosedClaim? in
+            guard let key = disclosure.key else { return nil }
+            return DisclosedClaim(
+                id: id, types: types, name: key, value: disclosure.value)
+        }
+
+        return PreparedSubmissionData(
+            vpToken: vpToken, descriptorMap: dm, disclosedClaims: disclosedClaims,
+            purpose: inputDescriptor.purpose)
+    }
+
+    func createVpTokenForJwtVc(
+        clientId: String,
+        nonce: String,
+        jwtVpJsonGenerator: JwtVpJsonGenerator?
+    ) throws -> PreparedSubmissionData {
+        guard let generator = jwtVpJsonGenerator else {
+            throw OpenIdProviderIllegalInputException.illegalCredentialInput
+        }
+        do {
+            let (_, payload, _) = try JWTUtil.decodeJwt(jwt: credential)
+            if let vcDictionary = payload["vc"] as? [String: Any],
+                let credentialSubject = vcDictionary["credentialSubject"] as? [String: Any]
+            {
+                let disclosedClaims = credentialSubject.map { key, value in
+                    return DisclosedClaim(
+                        id: id, types: types, name: key,
+                        value: value as? String)
+                }
+                let vpToken = generator.generateJwt(
+                    vcJwt: credential, headerOptions: HeaderOptions(),
+                    payloadOptions: JwtVpJsonPayloadOptions(aud: clientId, nonce: nonce))
+
+                let descriptorMap = JwtVpJsonPresentation.genDescriptorMap(
+                    inputDescriptorId: inputDescriptor.id)
+                return PreparedSubmissionData(
+                    vpToken: vpToken,
+                    descriptorMap: descriptorMap,
+                    disclosedClaims: disclosedClaims,
+                    purpose: nil
+                )
+            }
+            else {
+                throw OpenIdProviderIllegalInputException.illegalCredentialInput
+            }
+        }
+        catch {
+            print("Error: \(error)")
+            throw error
+        }
+    }
+
 }
 
 struct DisclosedClaim: Codable {

--- a/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderTypes.swift
@@ -19,9 +19,9 @@ struct DisclosedClaim: Codable {
     // let path: String   // when nested claim is supported, it may be needed
 }
 
-struct SharedContent: Codable {
+struct SharedCredential: Codable {
     let id: String
-    let sharedPurpose: String?
+    let purposeForSharing: String?
     let sharedClaims: [DisclosedClaim]
 }
 
@@ -30,7 +30,8 @@ struct TokenSendResult: Decodable {
     let location: String?
     let cookies: [String]?
 
-    let sharedContents: [SharedContent]?
+    let sharedIdToken: String?
+    let sharedCredentials: [SharedCredential]?
 }
 
 struct PreparedSubmissionData {

--- a/tw2023_wallet/Services/OID/Provider/ProviderUtils.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderUtils.swift
@@ -1,0 +1,84 @@
+//
+//  ProviderUtils.swift
+//  tw2023_wallet
+//
+//  Created by katsuyoshi ozaki on 2024/10/02.
+//
+
+import Foundation
+
+func conformToFormData(preparedData: [PreparedSubmissionData]) -> String? {
+    if preparedData.isEmpty {
+        return ""
+    }
+    else if preparedData.count == 1 {
+        return preparedData[0].vpToken
+    }
+    else {
+        let tokens = preparedData.map { $0.vpToken }
+        let jsonEncoder = JSONEncoder()
+        if let jsonData = try? jsonEncoder.encode(tokens),
+            let jsonString = String(data: jsonData, encoding: .utf8)
+        {
+            return jsonString
+        }
+        else {
+            return nil
+        }
+
+    }
+}
+
+func postFormData<T: Decodable>(
+    formData: [String: String],
+    url: URL,
+    responseMode: ResponseMode,
+    convert: ((Data, HTTPURLResponse, URL) throws -> T)? = nil,
+    using session: URLSession = URLSession.shared
+) async throws -> T {
+
+    var request: URLRequest
+
+    switch responseMode {
+        case .directPost:
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+
+            let formBody = formData.map { key, value in
+                let encodedKey =
+                    key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                let encodedValue =
+                    value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                return "\(encodedKey)=\(encodedValue.replacingOccurrences(of: "+", with: "%2B"))"
+            }.joined(separator: "&")
+
+            request.httpBody = formBody.data(using: .utf8)
+            request.setValue(
+                "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        default:
+            print("Unsupported responseMode : \(responseMode)")
+            throw OpenIdProviderIllegalStateException.illegalResponseModeState
+    }
+
+    do {
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        guard (200...399).contains(httpResponse.statusCode) else {
+            throw NetworkError.statusCodeNotSuccessful(httpResponse.statusCode)
+        }
+
+        if let convert = convert {
+            return try convert(data, httpResponse, url)
+        }
+        else {
+            return data as! T
+        }
+    }
+    catch {
+        throw NetworkError.other(error)
+    }
+}

--- a/tw2023_wallet/Services/OID/Provider/ProviderUtils.swift
+++ b/tw2023_wallet/Services/OID/Provider/ProviderUtils.swift
@@ -29,13 +29,12 @@ func conformToFormData(preparedData: [PreparedSubmissionData]) -> String? {
     }
 }
 
-func postFormData<T: Decodable>(
+func sendFormData(
     formData: [String: String],
     url: URL,
     responseMode: ResponseMode,
-    convert: ((Data, HTTPURLResponse, URL) throws -> T)? = nil,
     using session: URLSession = URLSession.shared
-) async throws -> T {
+) async throws -> (Data, HTTPURLResponse, URL) {
 
     var request: URLRequest
 
@@ -71,12 +70,7 @@ func postFormData<T: Decodable>(
             throw NetworkError.statusCodeNotSuccessful(httpResponse.statusCode)
         }
 
-        if let convert = convert {
-            return try convert(data, httpResponse, url)
-        }
-        else {
-            return data as! T
-        }
+        return (data, httpResponse, url)
     }
     catch {
         throw NetworkError.other(error)

--- a/tw2023_wallet/Services/OID/Types.swift
+++ b/tw2023_wallet/Services/OID/Types.swift
@@ -9,3 +9,75 @@ import Foundation
 
 typealias KeyPair = (publicKey: SecKey, privateKey: SecKey)
 typealias KeyPairData = (publicKey: (Data, Data), privateKey: Data)
+
+protocol KeyBinding {
+    func generateJwt(sdJwt: String, selectedDisclosures: [Disclosure], aud: String, nonce: String)
+        throws -> String
+}
+
+protocol JwtVpJsonGenerator {
+    func generateJwt(
+        vcJwt: String, headerOptions: HeaderOptions, payloadOptions: JwtVpJsonPayloadOptions
+    ) -> String
+    func getJwk() -> [String: String]
+}
+
+struct HeaderOptions: Codable {
+    var alg: String = "ES256"
+    var typ: String = "JWT"
+    var jwk: String? = nil
+}
+
+struct JwtVpJsonPayloadOptions: Codable {
+    var iss: String? = nil
+    var jti: String? = nil
+    var aud: String
+    var nbf: Int64? = nil
+    var iat: Int64? = nil
+    var exp: Int64? = nil
+    var nonce: String
+}
+
+struct VpJwtPayload {
+    var iss: String?
+    var jti: String?
+    var aud: String?
+    var nbf: Int64?
+    var iat: Int64?
+    var exp: Int64?
+    var nonce: String?
+    var vp: [String: Any]
+
+    enum CodingKeys: String, CodingKey {
+        case iss, jti, aud, nbf, iat, exp, nonce, vp
+    }
+
+    init(
+        iss: String?, jti: String?, aud: String?, nbf: Int64?, iat: Int64?, exp: Int64?,
+        nonce: String?, vp: [String: Any]
+    ) {
+        self.iss = iss
+        self.jti = jti
+        self.aud = aud
+        self.nbf = nbf
+        self.iat = iat
+        self.exp = exp
+        self.nonce = nonce
+        self.vp = vp
+    }
+
+    // 手動で辞書を構築し、エンコードするメソッド
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [:]
+        if let iss = iss { dict["iss"] = iss }
+        if let jti = jti { dict["jti"] = jti }
+        if let aud = aud { dict["aud"] = aud }
+        if let nbf = nbf { dict["nbf"] = nbf }
+        if let iat = iat { dict["iat"] = iat }
+        if let exp = exp { dict["exp"] = exp }
+        if let nonce = nonce { dict["nonce"] = nonce }
+        dict["vp"] = vp
+
+        return dict
+    }
+}

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -1132,7 +1132,11 @@ final class OpenIdProviderTests: XCTestCase {
                 return
             }
             let newAccount = accountManager.nextAccount()
-            idProvider.setSiopAccount(account: newAccount, accountManager: accountManager)
+
+            let publicKey = accountManager.getPublicKey(index: newAccount.index)
+            let privateKey = accountManager.getPrivateKey(index: newAccount.index)
+            let keyPair = KeyPairData(publicKey: publicKey, privateKey: privateKey)
+            idProvider.setSecp256k1KeyPair(keyPair: keyPair)
 
             let result = await idProvider.respondToken(
                 credentials: [credential], using: mockSession)

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -675,11 +675,10 @@ final class OpenIdProviderTests: XCTestCase {
         let keyBinding = KeyBindingImpl(keyAlias: Constants.Cryptography.KEY_BINDING)
         idProvider.setKeyBinding(keyBinding: keyBinding)
 
-        let preparedData = try idProvider.createVpTokenForSdJwtVc(
-            credential: credential,
-            presentationDefinition: presentationDefinition,
+        let preparedData = try credential.createVpTokenForSdJwtVc(
             clientId: "https://rp.example.com",
-            nonce: "dummy-nonce"
+            nonce: "dummy-nonce",
+            keyBinding: keyBinding
         )
         let parts = preparedData.vpToken.split(separator: "~").map(String.init)
         XCTAssertEqual(parts.count, 3)
@@ -723,11 +722,10 @@ final class OpenIdProviderTests: XCTestCase {
         let keyBinding = KeyBindingImpl(keyAlias: Constants.Cryptography.KEY_BINDING)
         idProvider.setKeyBinding(keyBinding: keyBinding)
 
-        let preparedData = try idProvider.createVpTokenForSdJwtVc(
-            credential: credential,
-            presentationDefinition: presentationDefinition,
+        let preparedData = try credential.createVpTokenForSdJwtVc(
             clientId: "https://rp.example.com",
-            nonce: "dummy-nonce"
+            nonce: "dummy-nonce",
+            keyBinding: keyBinding
         )
         let parts = preparedData.vpToken.split(separator: "~").map(String.init)
         XCTAssertEqual(parts.count, 4)
@@ -776,11 +774,10 @@ final class OpenIdProviderTests: XCTestCase {
             keyAlias: Constants.Cryptography.KEY_PAIR_ALIAS_FOR_KEY_JWT_VP_JSON)
         idProvider.setJwtVpJsonGenerator(jwtVpJsonGenerator: jwtVpJsonGenerator)
 
-        let preparedData = try idProvider.createVpTokenForJwtVc(
-            credential: credential,
-            presentationDefinition: presentationDefinition,
+        let preparedData = try credential.createVpTokenForJwtVc(
             clientId: "https://rp.example.com",
-            nonce: "dummy-nonce"
+            nonce: "dummy-nonce",
+            jwtVpJsonGenerator: jwtVpJsonGenerator
         )
         do {
             let decodedJwt = try JWTUtil.decodeJwt(jwt: preparedData.vpToken)

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -904,6 +904,12 @@ final class OpenIdProviderTests: XCTestCase {
 
             switch result {
                 case .success(let data):
+                    if let lastRequestData = MockURLProtocol.lastRequestBody,
+                        let postBodyString = String(data: lastRequestData, encoding: .utf8)
+                    {
+                        XCTAssertFalse(postBodyString.contains("id_token="))
+                        XCTAssertTrue(postBodyString.contains("vp_token="))
+                    }
                     if let sharedContents = data.sharedCredentials {
                         XCTAssertEqual(sharedContents.count, 1)
                         XCTAssertEqual(sharedContents[0].id, "internal-id-1")
@@ -1019,6 +1025,12 @@ final class OpenIdProviderTests: XCTestCase {
                 credentials: [credential1, credential2], using: mockSession)
             switch result {
                 case .success(let data):
+                    if let lastRequestData = MockURLProtocol.lastRequestBody,
+                        let postBodyString = String(data: lastRequestData, encoding: .utf8)
+                    {
+                        XCTAssertFalse(postBodyString.contains("id_token="))
+                        XCTAssertTrue(postBodyString.contains("vp_token="))
+                    }
                     if let sharedContents = data.sharedCredentials {
                         XCTAssertEqual(sharedContents.count, 2)
                         XCTAssertEqual(sharedContents[0].id, "internal-id-1")
@@ -1132,7 +1144,6 @@ final class OpenIdProviderTests: XCTestCase {
                     {
                         XCTAssertTrue(postBodyString.contains("id_token="))
                         XCTAssertTrue(postBodyString.contains("vp_token="))
-
                     }
 
                     if let sharedContents = data.sharedCredentials {

--- a/tw2023_walletTests/OpenIdProviderTests.swift
+++ b/tw2023_walletTests/OpenIdProviderTests.swift
@@ -412,8 +412,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition1.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         XCTAssertNil(selected)
     }
 
@@ -426,8 +426,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition1.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)
@@ -460,8 +460,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition2.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)
@@ -494,8 +494,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition3.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)
@@ -528,8 +528,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition4.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)
@@ -562,8 +562,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition4.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 1)
@@ -590,8 +590,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition5.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)
@@ -624,8 +624,8 @@ final class OpenIdProviderTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let presentationDefinition = try decoder.decode(
             PresentationDefinition.self, from: presentationDefinition6.data(using: .utf8)!)
-        let selected = matchVcToRequirement(
-            sdJwt: sdJwt, presentationDefinition: presentationDefinition)
+        let selected = presentationDefinition.matchSdJwtVcToRequirement(
+            sdJwt: sdJwt)
         if let (inputDescriptor, disclosures) = selected {
             XCTAssertEqual(inputDescriptor.id, "input1")
             XCTAssertEqual(disclosures.count, 2)


### PR DESCRIPTION
# Summary

Fixed so that `id_token` and `vp_token` can be sent at the same time.
Whether or not simultaneous submission is necessary is determined by looking at the `response_type` value of the AuthRequest.

# Changed

- The `OpenIdProvider` class has been modified. 
  - The existing implementation was performing up to the completion of token transmission. 
  - This existing implementation has been modified to just complete the creation of token data.
    - `respondSIOPResponse` -> `createSiopIdToken`
    - `respondVPResponse` -> `createVpToken`
  - And a new function to send the created tokens has been added separately.
    - `respondToken` 
- During initial development, we added a special implementation for connecting to the Matrix Synapse server. Specifically,  wallet followed the HTTP redirect after posting the token. This was against the specifications, so I removed it.
- In making the above modifications, refactoring was performed.