### PR TITLE
Fixed a bug related to parsing Disclosure.

### DIFF
--- a/tw2023_wallet/Services/OID/PresentationExchange.swift
+++ b/tw2023_wallet/Services/OID/PresentationExchange.swift
@@ -72,11 +72,12 @@ struct PresentationDefinition: Codable {
     func matchSdJwtVcToRequirement(sdJwt: String) -> (
         InputDescriptor, [DisclosureWithOptionality]
     )? {
-        let parts = sdJwt.split(separator: "~").map(String.init)
-        let newList = parts.count > 2 ? Array(parts.dropFirst().dropLast()) : []
+        guard let sdJwtParts = try? SDJwtUtil.divideSDJwt(sdJwt: sdJwt) else {
+            return nil
+        }
 
         // [Disclosure]
-        let allDisclosures = decodeDisclosureFunction(newList)
+        let allDisclosures = decodeDisclosureFunction(sdJwtParts.disclosures)
         let sourcePayload = Dictionary(
             uniqueKeysWithValues: allDisclosures.compactMap { disclosure in
                 if let key = disclosure.key, let value = disclosure.value {


### PR DESCRIPTION
Fixes #35 .

Fixed a problem in which the following form of SD-JWT's Disclosure could not be parsed correctly by modifying it to use existing utility functions instead of the original adhoc implementation.

https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#section-5
```
An SD-JWT with Disclosures and without a KB-JWT:
<Issuer-signed JWT>~<Disclosure 1>~<Disclosure N>~
```


